### PR TITLE
SB-011: Settlement strategy abstraction and balances endpoint

### DIFF
--- a/apps/backend/src/main/kotlin/com/splitbill/backend/events/EventBalanceService.kt
+++ b/apps/backend/src/main/kotlin/com/splitbill/backend/events/EventBalanceService.kt
@@ -27,7 +27,9 @@ class EventBalanceService(
     ): BalancesResponse {
         val event = requireEventMembership(eventId, accountId)
         val currency = requireNotNull(event.baseCurrency)
-        val algorithm = algorithmOverride ?: requireNotNull(event.defaultSettlementAlgorithm)
+        val algorithm = algorithmOverride
+            ?: event.defaultSettlementAlgorithm
+            ?: SettlementAlgorithm.MIN_TRANSFER
 
         val personIds = eventPersonRepository.findAllByEventIdOrderByCreatedAtAsc(eventId)
             .mapNotNull { it.id }
@@ -63,7 +65,6 @@ class EventBalanceService(
                 BalanceDto(
                     personId = personId,
                     netAmountInEventCurrency = (snapshotByPerson[personId] ?: BigDecimal.ZERO.scaleMoney())
-                        .scaleMoney()
                         .toPlainString(),
                     owes = owesByPerson[personId]
                         ?.sortedBy { it.counterpartyPersonId.toString() }

--- a/apps/backend/src/main/kotlin/com/splitbill/backend/events/EventBalanceService.kt
+++ b/apps/backend/src/main/kotlin/com/splitbill/backend/events/EventBalanceService.kt
@@ -1,6 +1,7 @@
 package com.splitbill.backend.events
 
 import com.splitbill.backend.events.settlement.domain.MinTransferSettlementStrategy
+import com.splitbill.backend.events.settlement.domain.MONEY_SCALE
 import com.splitbill.backend.events.settlement.domain.NetBalance
 import com.splitbill.backend.events.settlement.domain.PairwiseSettlementStrategy
 import com.splitbill.backend.events.settlement.domain.SettlementStrategy
@@ -88,5 +89,5 @@ class EventBalanceService(
         return event
     }
 
-    private fun BigDecimal.scaleMoney(): BigDecimal = setScale(4, RoundingMode.UNNECESSARY)
+    private fun BigDecimal.scaleMoney(): BigDecimal = setScale(MONEY_SCALE, RoundingMode.UNNECESSARY)
 }

--- a/apps/backend/src/main/kotlin/com/splitbill/backend/events/EventBalanceService.kt
+++ b/apps/backend/src/main/kotlin/com/splitbill/backend/events/EventBalanceService.kt
@@ -45,7 +45,7 @@ class EventBalanceService(
         val owedByPerson = personIds.associateWith { mutableListOf<BalanceCounterpartyAmountDto>() }
 
         transfers.forEach { transfer ->
-            val money = MoneyDto(amount = transfer.amount.scaleMoney(), currency = currency)
+            val money = MoneyDto(amount = transfer.amount.scaleMoney().toPlainString(), currency = currency)
             owesByPerson[transfer.fromPersonId]?.add(
                 BalanceCounterpartyAmountDto(counterpartyPersonId = transfer.toPersonId, amount = money)
             )
@@ -61,7 +61,9 @@ class EventBalanceService(
             balances = personIds.map { personId ->
                 BalanceDto(
                     personId = personId,
-                    netAmountInEventCurrency = (snapshotByPerson[personId] ?: BigDecimal.ZERO.scaleMoney()).scaleMoney(),
+                    netAmountInEventCurrency = (snapshotByPerson[personId] ?: BigDecimal.ZERO.scaleMoney())
+                        .scaleMoney()
+                        .toPlainString(),
                     owes = owesByPerson[personId]
                         ?.sortedBy { it.counterpartyPersonId.toString() }
                         ?: emptyList(),

--- a/apps/backend/src/main/kotlin/com/splitbill/backend/events/EventBalanceService.kt
+++ b/apps/backend/src/main/kotlin/com/splitbill/backend/events/EventBalanceService.kt
@@ -1,0 +1,90 @@
+package com.splitbill.backend.events
+
+import com.splitbill.backend.events.settlement.domain.MinTransferSettlementStrategy
+import com.splitbill.backend.events.settlement.domain.NetBalance
+import com.splitbill.backend.events.settlement.domain.PairwiseSettlementStrategy
+import com.splitbill.backend.events.settlement.domain.SettlementStrategy
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.util.UUID
+
+@Service
+class EventBalanceService(
+    private val eventRepository: EventRepository,
+    private val eventCollaboratorRepository: EventCollaboratorRepository,
+    private val eventPersonRepository: EventPersonRepository,
+    private val balanceSnapshotRepository: BalanceSnapshotRepository,
+    private val minTransferSettlementStrategy: MinTransferSettlementStrategy,
+    private val pairwiseSettlementStrategy: PairwiseSettlementStrategy
+) {
+
+    fun getBalances(
+        accountId: UUID,
+        eventId: UUID,
+        algorithmOverride: SettlementAlgorithm?
+    ): BalancesResponse {
+        val event = requireEventMembership(eventId, accountId)
+        val currency = requireNotNull(event.baseCurrency)
+        val algorithm = algorithmOverride ?: requireNotNull(event.defaultSettlementAlgorithm)
+
+        val personIds = eventPersonRepository.findAllByEventIdOrderByCreatedAtAsc(eventId)
+            .mapNotNull { it.id }
+        val snapshotByPerson = balanceSnapshotRepository.findAllByEventIdOrderByPersonIdAsc(eventId)
+            .associateBy({ requireNotNull(it.personId) }, { requireNotNull(it.netAmount).scaleMoney() })
+
+        val netBalances = personIds.map { personId ->
+            NetBalance(
+                personId = personId,
+                amount = snapshotByPerson[personId] ?: BigDecimal.ZERO.scaleMoney()
+            )
+        }
+
+        val transfers = strategyFor(algorithm).settle(netBalances)
+        val owesByPerson = personIds.associateWith { mutableListOf<BalanceCounterpartyAmountDto>() }
+        val owedByPerson = personIds.associateWith { mutableListOf<BalanceCounterpartyAmountDto>() }
+
+        transfers.forEach { transfer ->
+            val money = MoneyDto(amount = transfer.amount.scaleMoney(), currency = currency)
+            owesByPerson[transfer.fromPersonId]?.add(
+                BalanceCounterpartyAmountDto(counterpartyPersonId = transfer.toPersonId, amount = money)
+            )
+            owedByPerson[transfer.toPersonId]?.add(
+                BalanceCounterpartyAmountDto(counterpartyPersonId = transfer.fromPersonId, amount = money)
+            )
+        }
+
+        return BalancesResponse(
+            eventId = eventId,
+            currency = currency,
+            algorithm = algorithm,
+            balances = personIds.map { personId ->
+                BalanceDto(
+                    personId = personId,
+                    netAmountInEventCurrency = (snapshotByPerson[personId] ?: BigDecimal.ZERO.scaleMoney()).scaleMoney(),
+                    owes = owesByPerson[personId]
+                        ?.sortedBy { it.counterpartyPersonId.toString() }
+                        ?: emptyList(),
+                    owedBy = owedByPerson[personId]
+                        ?.sortedBy { it.counterpartyPersonId.toString() }
+                        ?: emptyList()
+                )
+            }
+        )
+    }
+
+    private fun strategyFor(algorithm: SettlementAlgorithm): SettlementStrategy = when (algorithm) {
+        SettlementAlgorithm.MIN_TRANSFER -> minTransferSettlementStrategy
+        SettlementAlgorithm.PAIRWISE -> pairwiseSettlementStrategy
+    }
+
+    private fun requireEventMembership(eventId: UUID, accountId: UUID): EventEntity {
+        val event = eventRepository.findByIdAndArchivedAtIsNull(eventId) ?: throw EventNotFoundException()
+        if (!eventCollaboratorRepository.existsByEventIdAndAccountId(eventId, accountId)) {
+            throw EventAccessDeniedException()
+        }
+        return event
+    }
+
+    private fun BigDecimal.scaleMoney(): BigDecimal = setScale(4, RoundingMode.UNNECESSARY)
+}

--- a/apps/backend/src/main/kotlin/com/splitbill/backend/events/EventController.kt
+++ b/apps/backend/src/main/kotlin/com/splitbill/backend/events/EventController.kt
@@ -20,6 +20,7 @@ import java.util.UUID
 @RestController
 class EventController(
     private val eventService: EventService,
+    private val eventBalanceService: EventBalanceService,
     private val entryService: EntryService,
     private val authService: AuthService
 ) {
@@ -52,6 +53,16 @@ class EventController(
     ): EventDetailsResponse {
         val account = authService.requireAuthenticated(authorizationHeader)
         return eventService.getEventDetails(account.id, eventId)
+    }
+
+    @GetMapping("/events/{eventId}/balances")
+    fun getBalances(
+        @RequestHeader("Authorization", required = false) authorizationHeader: String?,
+        @PathVariable eventId: UUID,
+        @RequestParam(required = false) algorithm: SettlementAlgorithm?
+    ): BalancesResponse {
+        val account = authService.requireAuthenticated(authorizationHeader)
+        return eventBalanceService.getBalances(account.id, eventId, algorithm)
     }
 
     @PatchMapping("/events/{eventId}")

--- a/apps/backend/src/main/kotlin/com/splitbill/backend/events/EventDtos.kt
+++ b/apps/backend/src/main/kotlin/com/splitbill/backend/events/EventDtos.kt
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
+import java.math.BigDecimal
 import java.time.Instant
 import java.util.UUID
 
@@ -105,6 +106,30 @@ data class JoinInviteRequest(
 data class JoinInviteResponse(
     val eventId: UUID,
     val personId: UUID
+)
+
+data class MoneyDto(
+    val amount: BigDecimal,
+    val currency: String
+)
+
+data class BalanceCounterpartyAmountDto(
+    val counterpartyPersonId: UUID,
+    val amount: MoneyDto
+)
+
+data class BalanceDto(
+    val personId: UUID,
+    val netAmountInEventCurrency: BigDecimal,
+    val owes: List<BalanceCounterpartyAmountDto>,
+    val owedBy: List<BalanceCounterpartyAmountDto>
+)
+
+data class BalancesResponse(
+    val eventId: UUID,
+    val currency: String,
+    val algorithm: SettlementAlgorithm,
+    val balances: List<BalanceDto>
 )
 
 data class PageParams(

--- a/apps/backend/src/main/kotlin/com/splitbill/backend/events/EventDtos.kt
+++ b/apps/backend/src/main/kotlin/com/splitbill/backend/events/EventDtos.kt
@@ -6,7 +6,6 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
-import java.math.BigDecimal
 import java.time.Instant
 import java.util.UUID
 
@@ -109,7 +108,7 @@ data class JoinInviteResponse(
 )
 
 data class MoneyDto(
-    val amount: BigDecimal,
+    val amount: String,
     val currency: String
 )
 
@@ -120,7 +119,7 @@ data class BalanceCounterpartyAmountDto(
 
 data class BalanceDto(
     val personId: UUID,
-    val netAmountInEventCurrency: BigDecimal,
+    val netAmountInEventCurrency: String,
     val owes: List<BalanceCounterpartyAmountDto>,
     val owedBy: List<BalanceCounterpartyAmountDto>
 )

--- a/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/MinTransferSettlementStrategy.kt
+++ b/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/MinTransferSettlementStrategy.kt
@@ -5,6 +5,16 @@ import java.util.UUID
 import kotlin.math.min
 
 @Component
+/**
+ * Greedy settlement strategy that prioritizes the largest outstanding creditor/debtor buckets
+ * first to reduce transfer count for the same net balance set.
+ *
+ * Input:
+ * - net balances where positive amounts are creditors and negative amounts are debtors.
+ *
+ * Output:
+ * - deterministic transfer list that settles balances with transfer-minimizing intent.
+ */
 class MinTransferSettlementStrategy : SettlementStrategy {
 
     override fun settle(netBalances: List<NetBalance>): List<SettlementTransfer> {

--- a/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/MinTransferSettlementStrategy.kt
+++ b/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/MinTransferSettlementStrategy.kt
@@ -1,0 +1,55 @@
+package com.splitbill.backend.events.settlement.domain
+
+import org.springframework.stereotype.Component
+import java.util.UUID
+import kotlin.math.min
+
+@Component
+class MinTransferSettlementStrategy : SettlementStrategy {
+
+    override fun settle(netBalances: List<NetBalance>): List<SettlementTransfer> {
+        val creditors = netBalances
+            .map { Bucket(it.personId, it.amount.toMinorUnits()) }
+            .filter { it.amount > 0L }
+            .toMutableList()
+        val debtors = netBalances
+            .map { Bucket(it.personId, -it.amount.toMinorUnits()) }
+            .filter { it.amount > 0L }
+            .toMutableList()
+
+        val transfers = mutableListOf<SettlementTransfer>()
+        while (creditors.isNotEmpty() && debtors.isNotEmpty()) {
+            creditors.sortWith(compareByDescending<Bucket> { it.amount }.thenBy { it.personId.toString() })
+            debtors.sortWith(compareByDescending<Bucket> { it.amount }.thenBy { it.personId.toString() })
+
+            val creditor = creditors.first()
+            val debtor = debtors.first()
+            val transferMinor = min(creditor.amount, debtor.amount)
+            if (transferMinor <= 0L) {
+                break
+            }
+
+            transfers += SettlementTransfer(
+                fromPersonId = debtor.personId,
+                toPersonId = creditor.personId,
+                amount = transferMinor.toMoneyAmount()
+            )
+
+            creditor.amount -= transferMinor
+            debtor.amount -= transferMinor
+            if (creditor.amount == 0L) {
+                creditors.removeAt(0)
+            }
+            if (debtor.amount == 0L) {
+                debtors.removeAt(0)
+            }
+        }
+
+        return transfers
+    }
+
+    private data class Bucket(
+        val personId: UUID,
+        var amount: Long
+    )
+}

--- a/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/MoneyScale.kt
+++ b/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/MoneyScale.kt
@@ -1,0 +1,4 @@
+package com.splitbill.backend.events.settlement.domain
+
+/** Canonical fixed money scale for Split-Bill v1 domain and persistence flows. */
+const val MONEY_SCALE: Int = 4

--- a/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/PairwiseSettlementStrategy.kt
+++ b/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/PairwiseSettlementStrategy.kt
@@ -5,6 +5,16 @@ import java.util.UUID
 import kotlin.math.min
 
 @Component
+/**
+ * Produces settlements by iterating debtors and paying creditors in deterministic id order.
+ *
+ * Input:
+ * - net balances where positive amounts are creditors and negative amounts are debtors.
+ *
+ * Output:
+ * - transfer list that fully settles all balances, potentially with more transfers than
+ *   MIN_TRANSFER, while remaining deterministic for equal inputs.
+ */
 class PairwiseSettlementStrategy : SettlementStrategy {
 
     override fun settle(netBalances: List<NetBalance>): List<SettlementTransfer> {

--- a/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/PairwiseSettlementStrategy.kt
+++ b/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/PairwiseSettlementStrategy.kt
@@ -1,0 +1,51 @@
+package com.splitbill.backend.events.settlement.domain
+
+import org.springframework.stereotype.Component
+import java.util.UUID
+import kotlin.math.min
+
+@Component
+class PairwiseSettlementStrategy : SettlementStrategy {
+
+    override fun settle(netBalances: List<NetBalance>): List<SettlementTransfer> {
+        val creditors = netBalances
+            .map { Bucket(it.personId, it.amount.toMinorUnits()) }
+            .filter { it.amount > 0L }
+            .sortedBy { it.personId.toString() }
+            .toMutableList()
+        val debtors = netBalances
+            .map { Bucket(it.personId, -it.amount.toMinorUnits()) }
+            .filter { it.amount > 0L }
+            .sortedBy { it.personId.toString() }
+
+        val transfers = mutableListOf<SettlementTransfer>()
+        for (debtor in debtors) {
+            var remaining = debtor.amount
+            for (creditor in creditors) {
+                if (remaining == 0L) {
+                    break
+                }
+                if (creditor.amount == 0L) {
+                    continue
+                }
+
+                val transferMinor = min(remaining, creditor.amount)
+                transfers += SettlementTransfer(
+                    fromPersonId = debtor.personId,
+                    toPersonId = creditor.personId,
+                    amount = transferMinor.toMoneyAmount()
+                )
+
+                remaining -= transferMinor
+                creditor.amount -= transferMinor
+            }
+        }
+
+        return transfers
+    }
+
+    private data class Bucket(
+        val personId: UUID,
+        var amount: Long
+    )
+}

--- a/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/SettlementAmountMath.kt
+++ b/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/SettlementAmountMath.kt
@@ -1,0 +1,15 @@
+package com.splitbill.backend.events.settlement.domain
+
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+private const val MONEY_SCALE = 4
+private val MONEY_FACTOR = BigDecimal.TEN.pow(MONEY_SCALE)
+
+internal fun BigDecimal.toMinorUnits(): Long = setScale(MONEY_SCALE, RoundingMode.UNNECESSARY)
+    .multiply(MONEY_FACTOR)
+    .longValueExact()
+
+internal fun Long.toMoneyAmount(): BigDecimal = BigDecimal.valueOf(this)
+    .divide(MONEY_FACTOR)
+    .setScale(MONEY_SCALE, RoundingMode.UNNECESSARY)

--- a/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/SettlementAmountMath.kt
+++ b/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/SettlementAmountMath.kt
@@ -3,11 +3,6 @@ package com.splitbill.backend.events.settlement.domain
 import java.math.BigDecimal
 import java.math.RoundingMode
 
-/**
- * Split-Bill v1 stores money with fixed 4-decimal precision in persistence and domain flows.
- * Currency-specific minor units can be introduced later together with a data model migration.
- */
-private const val MONEY_SCALE = 4
 private val MONEY_FACTOR = BigDecimal.TEN.pow(MONEY_SCALE)
 
 /** Converts scaled decimal money to fixed minor units used by settlement strategies. */

--- a/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/SettlementAmountMath.kt
+++ b/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/SettlementAmountMath.kt
@@ -3,13 +3,19 @@ package com.splitbill.backend.events.settlement.domain
 import java.math.BigDecimal
 import java.math.RoundingMode
 
+/**
+ * Split-Bill v1 stores money with fixed 4-decimal precision in persistence and domain flows.
+ * Currency-specific minor units can be introduced later together with a data model migration.
+ */
 private const val MONEY_SCALE = 4
 private val MONEY_FACTOR = BigDecimal.TEN.pow(MONEY_SCALE)
 
+/** Converts scaled decimal money to fixed minor units used by settlement strategies. */
 internal fun BigDecimal.toMinorUnits(): Long = setScale(MONEY_SCALE, RoundingMode.UNNECESSARY)
     .multiply(MONEY_FACTOR)
     .longValueExact()
 
+/** Converts fixed minor units back to scaled decimal money. */
 internal fun Long.toMoneyAmount(): BigDecimal = BigDecimal.valueOf(this)
     .divide(MONEY_FACTOR)
     .setScale(MONEY_SCALE, RoundingMode.UNNECESSARY)

--- a/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/SettlementDomainModel.kt
+++ b/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/SettlementDomainModel.kt
@@ -14,6 +14,17 @@ data class SettlementTransfer(
     val amount: BigDecimal
 )
 
+/**
+ * Strategy contract for transforming participant net balances into settlement transfers.
+ *
+ * Input:
+ * - `netBalances`: one entry per person, where positive means the person is owed money and
+ *   negative means the person owes money.
+ *
+ * Output:
+ * - list of directed transfers (`fromPersonId` -> `toPersonId`) whose amounts settle the
+ *   provided net balances under the strategy's policy.
+ */
 interface SettlementStrategy {
     fun settle(netBalances: List<NetBalance>): List<SettlementTransfer>
 }

--- a/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/SettlementDomainModel.kt
+++ b/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/SettlementDomainModel.kt
@@ -5,12 +5,14 @@ import java.util.UUID
 
 data class NetBalance(
     val personId: UUID,
+    /** Signed amount in event currency, scaled to MONEY_SCALE. */
     val amount: BigDecimal
 )
 
 data class SettlementTransfer(
     val fromPersonId: UUID,
     val toPersonId: UUID,
+    /** Transfer amount in event currency, scaled to MONEY_SCALE. */
     val amount: BigDecimal
 )
 

--- a/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/SettlementDomainModel.kt
+++ b/apps/backend/src/main/kotlin/com/splitbill/backend/events/settlement/domain/SettlementDomainModel.kt
@@ -1,0 +1,19 @@
+package com.splitbill.backend.events.settlement.domain
+
+import java.math.BigDecimal
+import java.util.UUID
+
+data class NetBalance(
+    val personId: UUID,
+    val amount: BigDecimal
+)
+
+data class SettlementTransfer(
+    val fromPersonId: UUID,
+    val toPersonId: UUID,
+    val amount: BigDecimal
+)
+
+interface SettlementStrategy {
+    fun settle(netBalances: List<NetBalance>): List<SettlementTransfer>
+}

--- a/apps/backend/src/test/kotlin/com/splitbill/backend/EventBalancesIntegrationTests.kt
+++ b/apps/backend/src/test/kotlin/com/splitbill/backend/EventBalancesIntegrationTests.kt
@@ -22,6 +22,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.math.BigDecimal
 
 @Import(TestcontainersConfiguration::class)
 @SpringBootTest
@@ -75,9 +76,9 @@ class EventBalancesIntegrationTests(
         assertEquals("USD", defaultBalances.path("currency").asText())
         assertEquals("PAIRWISE", defaultBalances.path("algorithm").asText())
         val defaultByPerson = balanceByPerson(defaultBalances)
-        assertEquals(6.0, requireNotNull(defaultByPerson[alice]).path("netAmountInEventCurrency").asDouble(), 0.0001)
-        assertEquals(-3.0, requireNotNull(defaultByPerson[bob]).path("netAmountInEventCurrency").asDouble(), 0.0001)
-        assertEquals(-3.0, requireNotNull(defaultByPerson[carol]).path("netAmountInEventCurrency").asDouble(), 0.0001)
+        assertEquals("6.0000", requireNotNull(defaultByPerson[alice]).path("netAmountInEventCurrency").asText())
+        assertEquals("-3.0000", requireNotNull(defaultByPerson[bob]).path("netAmountInEventCurrency").asText())
+        assertEquals("-3.0000", requireNotNull(defaultByPerson[carol]).path("netAmountInEventCurrency").asText())
 
         val overrideBalances = readJson(
             mockMvc.perform(
@@ -92,7 +93,7 @@ class EventBalancesIntegrationTests(
 
         assertEquals("MIN_TRANSFER", overrideBalances.path("algorithm").asText())
         val overrideByPerson = balanceByPerson(overrideBalances)
-        assertEquals(6.0, requireNotNull(overrideByPerson[alice]).path("netAmountInEventCurrency").asDouble(), 0.0001)
+        assertEquals("6.0000", requireNotNull(overrideByPerson[alice]).path("netAmountInEventCurrency").asText())
     }
 
     @Test
@@ -109,6 +110,118 @@ class EventBalancesIntegrationTests(
         )
             .andExpect(status().isForbidden)
             .andExpect(jsonPath("$.code").value("EVENT_ACCESS_DENIED"))
+    }
+
+    @Test
+    fun `balances matrix covers mixed split modes and multiple entries for both algorithms`() {
+        for (algorithm in listOf("PAIRWISE", "MIN_TRANSFER")) {
+            val owner = registerAndVerify("owner-balances-matrix-$algorithm@splitbill.test")
+            val token = owner.path("tokens").path("accessToken").asText()
+            val eventId = createEvent(token, "Matrix Event $algorithm", "MIN_TRANSFER")
+            val alice = createPerson(token, eventId, "Alice")
+            val bob = createPerson(token, eventId, "Bob")
+            val carol = createPerson(token, eventId, "Carol")
+            val dave = createPerson(token, eventId, "Dave")
+
+            createEntry(
+                token = token,
+                eventId = eventId,
+                type = "EXPENSE",
+                name = "Hotel",
+                amount = "12.0000",
+                payerPersonId = alice,
+                participants = listOf(
+                    mapOf("personId" to alice, "splitMode" to "EVEN"),
+                    mapOf("personId" to bob, "splitMode" to "EVEN"),
+                    mapOf("personId" to carol, "splitMode" to "EVEN")
+                )
+            )
+            createEntry(
+                token = token,
+                eventId = eventId,
+                type = "INCOME",
+                name = "Refund",
+                amount = "6.0000",
+                payerPersonId = dave,
+                participants = listOf(
+                    mapOf("personId" to bob, "splitMode" to "AMOUNT", "splitAmount" to "2.0000"),
+                    mapOf("personId" to carol, "splitMode" to "AMOUNT", "splitAmount" to "4.0000")
+                )
+            )
+            createEntry(
+                token = token,
+                eventId = eventId,
+                type = "EXPENSE",
+                name = "Taxi",
+                amount = "9.0000",
+                payerPersonId = bob,
+                participants = listOf(
+                    mapOf("personId" to alice, "splitMode" to "PERCENT", "splitPercent" to "50.00"),
+                    mapOf("personId" to carol, "splitMode" to "PERCENT", "splitPercent" to "50.00")
+                )
+            )
+
+            val balances = readJson(
+                mockMvc.perform(
+                    get("/events/$eventId/balances")
+                        .param("algorithm", algorithm)
+                        .header("Authorization", "Bearer $token")
+                )
+                    .andExpect(status().isOk)
+                    .andExpect(jsonPath("$.algorithm").value(algorithm))
+                    .andReturn()
+            )
+
+            val byPerson = balanceByPerson(balances)
+            assertEquals("3.5000", requireNotNull(byPerson[alice]).path("netAmountInEventCurrency").asText())
+            assertEquals("7.0000", requireNotNull(byPerson[bob]).path("netAmountInEventCurrency").asText())
+            assertEquals("-4.5000", requireNotNull(byPerson[carol]).path("netAmountInEventCurrency").asText())
+            assertEquals("-6.0000", requireNotNull(byPerson[dave]).path("netAmountInEventCurrency").asText())
+            assertTransfersConserveNet(byPerson)
+        }
+    }
+
+    @Test
+    fun `balances matrix covers decimal precision scenario for both algorithms`() {
+        for (algorithm in listOf("PAIRWISE", "MIN_TRANSFER")) {
+            val owner = registerAndVerify("owner-balances-precision-$algorithm@splitbill.test")
+            val token = owner.path("tokens").path("accessToken").asText()
+            val eventId = createEvent(token, "Precision Event $algorithm", "PAIRWISE")
+            val alice = createPerson(token, eventId, "Alice")
+            val bob = createPerson(token, eventId, "Bob")
+            val carol = createPerson(token, eventId, "Carol")
+
+            createEntry(
+                token = token,
+                eventId = eventId,
+                type = "EXPENSE",
+                name = "Coffee",
+                amount = "1.0000",
+                payerPersonId = alice,
+                participants = listOf(
+                    mapOf("personId" to alice, "splitMode" to "PERCENT", "splitPercent" to "33.34"),
+                    mapOf("personId" to bob, "splitMode" to "PERCENT", "splitPercent" to "33.33"),
+                    mapOf("personId" to carol, "splitMode" to "PERCENT", "splitPercent" to "33.33")
+                )
+            )
+
+            val balances = readJson(
+                mockMvc.perform(
+                    get("/events/$eventId/balances")
+                        .param("algorithm", algorithm)
+                        .header("Authorization", "Bearer $token")
+                )
+                    .andExpect(status().isOk)
+                    .andExpect(jsonPath("$.algorithm").value(algorithm))
+                    .andReturn()
+            )
+
+            val byPerson = balanceByPerson(balances)
+            assertEquals("0.6666", requireNotNull(byPerson[alice]).path("netAmountInEventCurrency").asText())
+            assertEquals("-0.3333", requireNotNull(byPerson[bob]).path("netAmountInEventCurrency").asText())
+            assertEquals("-0.3333", requireNotNull(byPerson[carol]).path("netAmountInEventCurrency").asText())
+            assertTransfersConserveNet(byPerson)
+        }
     }
 
     private fun registerAndVerify(email: String): JsonNode {
@@ -169,6 +282,30 @@ class EventBalancesIntegrationTests(
     }
 
     private fun createExpenseEntry(token: String, eventId: String, payer: String, participantA: String, participantB: String) {
+        createEntry(
+            token = token,
+            eventId = eventId,
+            type = "EXPENSE",
+            name = "Dinner",
+            amount = "9.0000",
+            payerPersonId = payer,
+            participants = listOf(
+                mapOf("personId" to payer, "splitMode" to "EVEN"),
+                mapOf("personId" to participantA, "splitMode" to "EVEN"),
+                mapOf("personId" to participantB, "splitMode" to "EVEN")
+            )
+        )
+    }
+
+    private fun createEntry(
+        token: String,
+        eventId: String,
+        type: String,
+        name: String,
+        amount: String,
+        payerPersonId: String,
+        participants: List<Map<String, Any>>
+    ) {
         mockMvc.perform(
             post("/events/$eventId/entries")
                 .header("Authorization", "Bearer $token")
@@ -176,17 +313,13 @@ class EventBalancesIntegrationTests(
                 .content(
                     json(
                         mapOf(
-                            "type" to "EXPENSE",
-                            "name" to "Dinner",
-                            "amount" to "9.0000",
+                            "type" to type,
+                            "name" to name,
+                            "amount" to amount,
                             "currency" to "USD",
-                            "payerPersonId" to payer,
+                            "payerPersonId" to payerPersonId,
                             "occurredAtUtc" to "2026-03-01T12:00:00Z",
-                            "participants" to listOf(
-                                mapOf("personId" to payer, "splitMode" to "EVEN"),
-                                mapOf("personId" to participantA, "splitMode" to "EVEN"),
-                                mapOf("personId" to participantB, "splitMode" to "EVEN")
-                            )
+                            "participants" to participants
                         )
                     )
                 )
@@ -199,6 +332,19 @@ class EventBalancesIntegrationTests(
 
     private fun balanceByPerson(response: JsonNode): Map<String, JsonNode> =
         response.path("balances").associateBy { it.path("personId").asText() }
+
+    private fun assertTransfersConserveNet(byPerson: Map<String, JsonNode>) {
+        byPerson.values.forEach { balanceNode ->
+            val net = BigDecimal(balanceNode.path("netAmountInEventCurrency").asText())
+            val owedByTotal = balanceNode.path("owedBy").sumOf {
+                BigDecimal(it.path("amount").path("amount").asText())
+            }
+            val owesTotal = balanceNode.path("owes").sumOf {
+                BigDecimal(it.path("amount").path("amount").asText())
+            }
+            assertEquals(net, owedByTotal.subtract(owesTotal))
+        }
+    }
 
     private fun json(payload: Any): String = objectMapper.writeValueAsString(payload)
 }

--- a/apps/backend/src/test/kotlin/com/splitbill/backend/EventBalancesIntegrationTests.kt
+++ b/apps/backend/src/test/kotlin/com/splitbill/backend/EventBalancesIntegrationTests.kt
@@ -1,0 +1,204 @@
+package com.splitbill.backend
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.splitbill.backend.auth.AccountRepository
+import com.splitbill.backend.events.BalanceSnapshotRepository
+import com.splitbill.backend.events.EntryParticipantRepository
+import com.splitbill.backend.events.EntryRepository
+import com.splitbill.backend.events.EventCollaboratorRepository
+import com.splitbill.backend.events.EventPersonRepository
+import com.splitbill.backend.events.EventRepository
+import com.splitbill.backend.events.InviteTokenRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@Import(TestcontainersConfiguration::class)
+@SpringBootTest
+@AutoConfigureMockMvc
+class EventBalancesIntegrationTests(
+    @Autowired private val mockMvc: MockMvc,
+    @Autowired private val accountRepository: AccountRepository,
+    @Autowired private val eventRepository: EventRepository,
+    @Autowired private val eventCollaboratorRepository: EventCollaboratorRepository,
+    @Autowired private val eventPersonRepository: EventPersonRepository,
+    @Autowired private val inviteTokenRepository: InviteTokenRepository,
+    @Autowired private val entryRepository: EntryRepository,
+    @Autowired private val entryParticipantRepository: EntryParticipantRepository,
+    @Autowired private val balanceSnapshotRepository: BalanceSnapshotRepository
+) {
+    private val objectMapper = ObjectMapper().findAndRegisterModules()
+
+    @BeforeEach
+    fun setup() {
+        entryParticipantRepository.deleteAllInBatch()
+        entryRepository.deleteAllInBatch()
+        balanceSnapshotRepository.deleteAllInBatch()
+        eventCollaboratorRepository.deleteAllInBatch()
+        eventPersonRepository.deleteAllInBatch()
+        inviteTokenRepository.deleteAllInBatch()
+        eventRepository.deleteAllInBatch()
+        accountRepository.deleteAllInBatch()
+    }
+
+    @Test
+    fun `balances endpoint uses default algorithm and supports override`() {
+        val owner = registerAndVerify("owner-balances@splitbill.test")
+        val token = owner.path("tokens").path("accessToken").asText()
+        val eventId = createEvent(token, "Balances Event", "PAIRWISE")
+        val alice = createPerson(token, eventId, "Alice")
+        val bob = createPerson(token, eventId, "Bob")
+        val carol = createPerson(token, eventId, "Carol")
+
+        createExpenseEntry(token, eventId, alice, bob, carol)
+
+        val defaultBalances = readJson(
+            mockMvc.perform(
+                get("/events/$eventId/balances")
+                    .header("Authorization", "Bearer $token")
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.algorithm").value("PAIRWISE"))
+                .andReturn()
+        )
+
+        assertEquals("USD", defaultBalances.path("currency").asText())
+        assertEquals("PAIRWISE", defaultBalances.path("algorithm").asText())
+        val defaultByPerson = balanceByPerson(defaultBalances)
+        assertEquals(6.0, requireNotNull(defaultByPerson[alice]).path("netAmountInEventCurrency").asDouble(), 0.0001)
+        assertEquals(-3.0, requireNotNull(defaultByPerson[bob]).path("netAmountInEventCurrency").asDouble(), 0.0001)
+        assertEquals(-3.0, requireNotNull(defaultByPerson[carol]).path("netAmountInEventCurrency").asDouble(), 0.0001)
+
+        val overrideBalances = readJson(
+            mockMvc.perform(
+                get("/events/$eventId/balances")
+                    .param("algorithm", "MIN_TRANSFER")
+                    .header("Authorization", "Bearer $token")
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.algorithm").value("MIN_TRANSFER"))
+                .andReturn()
+        )
+
+        assertEquals("MIN_TRANSFER", overrideBalances.path("algorithm").asText())
+        val overrideByPerson = balanceByPerson(overrideBalances)
+        assertEquals(6.0, requireNotNull(overrideByPerson[alice]).path("netAmountInEventCurrency").asDouble(), 0.0001)
+    }
+
+    @Test
+    fun `non collaborator cannot access balances`() {
+        val owner = registerAndVerify("owner-balances-deny@splitbill.test")
+        val ownerToken = owner.path("tokens").path("accessToken").asText()
+        val eventId = createEvent(ownerToken, "Restricted Balances", null)
+        val stranger = registerAndVerify("stranger-balances-deny@splitbill.test")
+        val strangerToken = stranger.path("tokens").path("accessToken").asText()
+
+        mockMvc.perform(
+            get("/events/$eventId/balances")
+                .header("Authorization", "Bearer $strangerToken")
+        )
+            .andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.code").value("EVENT_ACCESS_DENIED"))
+    }
+
+    private fun registerAndVerify(email: String): JsonNode {
+        val register = mockMvc.perform(
+            post("/auth/register")
+                .contentType("application/json")
+                .content(json(mapOf("email" to email, "password" to "StrongPass123!", "name" to "User")))
+        )
+            .andExpect(status().isCreated)
+            .andReturn()
+
+        val session = objectMapper.readTree(register.response.contentAsString)
+        val accountId = session.path("account").path("id").asText()
+
+        mockMvc.perform(
+            post("/auth/verify-email")
+                .contentType("application/json")
+                .content(json(mapOf("token" to accountId)))
+        )
+            .andExpect(status().isOk)
+
+        return session
+    }
+
+    private fun createEvent(token: String, name: String, defaultAlgorithm: String?): String {
+        val payload = mutableMapOf(
+            "name" to name,
+            "baseCurrency" to "USD",
+            "timezone" to "UTC"
+        )
+        if (defaultAlgorithm != null) {
+            payload["defaultSettlementAlgorithm"] = defaultAlgorithm
+        }
+
+        val result = mockMvc.perform(
+            post("/events")
+                .header("Authorization", "Bearer $token")
+                .contentType("application/json")
+                .content(json(payload))
+        )
+            .andExpect(status().isCreated)
+            .andReturn()
+
+        return objectMapper.readTree(result.response.contentAsString).path("event").path("id").asText()
+    }
+
+    private fun createPerson(token: String, eventId: String, displayName: String): String {
+        val result = mockMvc.perform(
+            post("/events/$eventId/people")
+                .header("Authorization", "Bearer $token")
+                .contentType("application/json")
+                .content(json(mapOf("displayName" to displayName)))
+        )
+            .andExpect(status().isCreated)
+            .andReturn()
+
+        return objectMapper.readTree(result.response.contentAsString).path("person").path("id").asText()
+    }
+
+    private fun createExpenseEntry(token: String, eventId: String, payer: String, participantA: String, participantB: String) {
+        mockMvc.perform(
+            post("/events/$eventId/entries")
+                .header("Authorization", "Bearer $token")
+                .contentType("application/json")
+                .content(
+                    json(
+                        mapOf(
+                            "type" to "EXPENSE",
+                            "name" to "Dinner",
+                            "amount" to "9.0000",
+                            "currency" to "USD",
+                            "payerPersonId" to payer,
+                            "occurredAtUtc" to "2026-03-01T12:00:00Z",
+                            "participants" to listOf(
+                                mapOf("personId" to payer, "splitMode" to "EVEN"),
+                                mapOf("personId" to participantA, "splitMode" to "EVEN"),
+                                mapOf("personId" to participantB, "splitMode" to "EVEN")
+                            )
+                        )
+                    )
+                )
+        )
+            .andExpect(status().isCreated)
+    }
+
+    private fun readJson(result: org.springframework.test.web.servlet.MvcResult): JsonNode =
+        objectMapper.readTree(result.response.contentAsString)
+
+    private fun balanceByPerson(response: JsonNode): Map<String, JsonNode> =
+        response.path("balances").associateBy { it.path("personId").asText() }
+
+    private fun json(payload: Any): String = objectMapper.writeValueAsString(payload)
+}


### PR DESCRIPTION
## Summary\n- add a DDD-oriented settlement domain abstraction (SettlementStrategy) with pluggable strategy implementations (MIN_TRANSFER, PAIRWISE)\n- implement EventBalanceService to compute balances/owes/owedBy using event snapshots plus selected settlement strategy\n- expose GET /events/{eventId}/balances with optional lgorithm override (falls back to event default)\n- add integration tests for default algorithm, query override, and collaborator authorization\n\n## Scope\n- Discipline: ackend\n- Issue: Closes #11\n\n## Contract/API\n- No contract changes required (endpoint and DTOs already defined in OpenAPI/contracts)\n- No DB migration changes\n\n## Validation\n- cd apps/backend && ./gradlew test\n  - PASS\n\n## Notes\n- keeps settlement algorithm extensibility isolated from entry ledger recomputation logic\n- keeps deterministic transfer outputs by explicit ordering and fixed-scale amount math