### PR TITLE
feat: add receipt import flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ Thumbs.db
 
 dist/
 build/
+playwright-results/
+playwright-results-receipt-import/
 playwright-report/
 test-results/
 *.tsbuildinfo

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,8 @@ export default tseslint.config(
   {
     ignores: [
       "dist",
+      "playwright-results",
+      "playwright-results-receipt-import",
       "playwright-report",
       "test-results",
       "apps/**",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,11 @@
         "@mui/icons-material": "^7.3.2",
         "@mui/material": "^7.3.2",
         "@react-pdf/renderer": "^4.3.2",
+        "pdfjs-dist": "^5.5.207",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-hook-form": "^7.62.0",
+        "tesseract.js": "^7.0.0",
         "zod": "^4.1.8"
       },
       "devDependencies": {
@@ -1760,6 +1762,256 @@
         }
       }
     },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.96.tgz",
+      "integrity": "sha512-6NNmNxvoJKeucVjxaaRUt3La2i5jShgiAbaY3G/72s1Vp3U06XPrAIxkAjBxpDcamEn/t+WJ4OOlGmvILo4/Ew==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.96",
+        "@napi-rs/canvas-darwin-arm64": "0.1.96",
+        "@napi-rs/canvas-darwin-x64": "0.1.96",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.96",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.96",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.96",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.96",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.96",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.96",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.96",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.96"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.96.tgz",
+      "integrity": "sha512-ew1sPrN3dGdZ3L4FoohPfnjq0f9/Jk7o+wP7HkQZokcXgIUD6FIyICEWGhMYzv53j63wUcPvZeAwgewX58/egg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.96.tgz",
+      "integrity": "sha512-Q/wOXZ5PzTqpdmA5eUOcegCf4Go/zz3aZ5DlzSeDpOjFmfwMKh8EzLAoweQ+mJVagcHQyzoJhaTEnrO68TNyNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.96.tgz",
+      "integrity": "sha512-UrXiQz28tQEvGM1qvyptewOAfmUrrd5+wvi6Rzjj2VprZI8iZ2KIvBD2lTTG1bVF95AbeDeG7PJA0D9sLKaOFA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.96.tgz",
+      "integrity": "sha512-I90ODxweD8aEP6XKU/NU+biso95MwCtQ2F46dUvhec1HesFi0tq/tAJkYic/1aBSiO/1kGKmSeD1B0duOHhEHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.96.tgz",
+      "integrity": "sha512-Dx/0+RFV++w3PcRy+4xNXkghhXjA5d0Mw1bs95emn5Llinp1vihMaA6WJt3oYv2LAHc36+gnrhIBsPhUyI2SGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.96.tgz",
+      "integrity": "sha512-UvOi7fii3IE2KDfEfhh8m+LpzSRvhGK7o1eho99M2M0HTik11k3GX+2qgVx9EtujN3/bhFFS1kSO3+vPMaJ0Mg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.96.tgz",
+      "integrity": "sha512-MBSukhGCQ5nRtf9NbFYWOU080yqkZU1PbuH4o1ROvB4CbPl12fchDR35tU83Wz8gWIM9JTn99lBn9DenPIv7Ig==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.96.tgz",
+      "integrity": "sha512-I/ccu2SstyKiV3HIeVzyBIWfrJo8cN7+MSQZPnabewWV6hfJ2nY7Df2WqOHmobBRUw84uGR6zfQHsUEio/m5Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.96.tgz",
+      "integrity": "sha512-H3uov7qnTl73GDT4h52lAqpJPsl1tIUyNPWJyhQ6gHakohNqqRq3uf80+NEpzcytKGEOENP1wX3yGwZxhjiWEQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.96.tgz",
+      "integrity": "sha512-ATp6Y+djOjYtkfV/VRH7CZ8I1MEtkUQBmKUbuWw5zWEHHqfL0cEcInE4Cxgx7zkNAhEdBbnH8HMVrqNp+/gwxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.96.tgz",
+      "integrity": "sha512-UYGdTltVd+Z8mcIuoqGmAXXUvwH5CLf2M6mIB5B0/JmX5J041jETjqtSYl7gN+aj3k1by/SG6sS0hAwCqyK7zw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
@@ -3165,6 +3417,12 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -4160,6 +4418,12 @@
       "integrity": "sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==",
       "license": "ISC"
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4586,6 +4850,55 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/node-readable-to-web-readable-stream": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
+      "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -4609,6 +4922,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "license": "MIT",
+      "bin": {
+        "opencollective-postinstall": "index.js"
       }
     },
     "node_modules/optionator": {
@@ -4766,6 +5088,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.5.207",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.5.207.tgz",
+      "integrity": "sha512-WMqqw06w1vUt9ZfT0gOFhMf3wHsWhaCrxGrckGs5Cci6ybDW87IvPaOd2pnBwT6BJuP/CzXDZxjFgmSULLdsdw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0 || >=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.95",
+        "node-readable-to-web-readable-stream": "^0.4.2"
       }
     },
     "node_modules/picocolors": {
@@ -5036,6 +5371,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -5351,6 +5692,30 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tesseract.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-7.0.0.tgz",
+      "integrity": "sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "tesseract.js-core": "^7.0.0",
+        "wasm-feature-detect": "^1.8.0",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/tesseract.js-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-7.0.0.tgz",
+      "integrity": "sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==",
+      "license": "Apache-2.0"
     },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
@@ -5815,6 +6180,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -5956,6 +6327,15 @@
       "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
       "license": "MIT"
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
     "@mui/icons-material": "^7.3.2",
     "@mui/material": "^7.3.2",
     "@react-pdf/renderer": "^4.3.2",
+    "pdfjs-dist": "^5.5.207",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.62.0",
+    "tesseract.js": "^7.0.0",
     "zod": "^4.1.8"
   },
   "devDependencies": {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -6,12 +6,17 @@ import App from "./App";
 import { STORAGE_KEY } from "./domain/splitter";
 import { appTheme } from "./theme";
 
-const { exportSettlementPdfMock } = vi.hoisted(() => ({
-  exportSettlementPdfMock: vi.fn()
+const { exportSettlementPdfMock, importReceiptMock } = vi.hoisted(() => ({
+  exportSettlementPdfMock: vi.fn(),
+  importReceiptMock: vi.fn()
 }));
 
 vi.mock("./pdf/exportSettlementPdf", () => ({
   exportSettlementPdf: exportSettlementPdfMock
+}));
+
+vi.mock("./receipt-import/importReceipt", () => ({
+  importReceipt: importReceiptMock
 }));
 
 function renderApp() {
@@ -47,6 +52,7 @@ describe("App", () => {
   beforeEach(() => {
     window.localStorage.clear();
     exportSettlementPdfMock.mockReset();
+    importReceiptMock.mockReset();
   });
 
   afterEach(() => {
@@ -225,4 +231,65 @@ describe("App", () => {
     });
     expect(await screen.findByText("PDF exported.")).toBeInTheDocument();
   });
+
+  it("imports a receipt in step 2 and appends editable items", async () => {
+    importReceiptMock.mockResolvedValueOnce({
+      source: "image",
+      fileName: "receipt.png",
+      rawText: "Apples 2.49\nBread 1.20",
+      items: [
+        { name: "Apples", price: "2.49" },
+        { name: "Bread", price: "1.20" }
+      ],
+      warnings: [{ code: "ignored-summary-lines", message: "Ignored 1 total or payment lines." }]
+    });
+
+    const user = userEvent.setup();
+    renderApp();
+
+    await user.click(screen.getByRole("button", { name: "Start splitting" }));
+    await addParticipant(user, "Ana");
+    await addParticipant(user, "Bruno");
+    await user.click(getContinueButton());
+    await user.click(getAddItemButton());
+    await user.type(screen.getByLabelText("Item name"), "Milk");
+    await user.type(screen.getByLabelText("Price"), "5.00");
+
+    const file = new File(["mock"], "receipt.png", { type: "image/png" });
+    await user.upload(screen.getByLabelText("Import receipt file"), file);
+
+    expect(importReceiptMock).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText(/Imported 2 items from receipt\.png/)).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Milk")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Apples")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Bread")).toBeInTheDocument();
+    expect(screen.getByText("Ignored 1 total or payment lines.")).toBeInTheDocument();
+  });
+
+  it(
+    "resets all step 2 items at once",
+    async () => {
+      const user = userEvent.setup();
+      renderApp();
+
+      await user.click(screen.getByRole("button", { name: "Start splitting" }));
+      await addParticipant(user, "Ana");
+      await addParticipant(user, "Bruno");
+      await user.click(getContinueButton());
+
+      await user.click(getAddItemButton());
+      await user.type(screen.getAllByLabelText("Item name")[0] as HTMLElement, "Milk");
+      await user.type(screen.getAllByLabelText("Price")[0] as HTMLElement, "5.00");
+      await user.click(getAddItemButton());
+      await user.type(screen.getAllByLabelText("Item name")[1] as HTMLElement, "Bread");
+      await user.type(screen.getAllByLabelText("Price")[1] as HTMLElement, "2.00");
+
+      await user.click(screen.getByRole("button", { name: "Reset items" }));
+
+      expect(screen.queryByDisplayValue("Milk")).not.toBeInTheDocument();
+      expect(screen.queryByDisplayValue("Bread")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Add item" })).toBeInTheDocument();
+    },
+    15000
+  );
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1021,8 +1021,8 @@ function App() {
                     )}
 
                     {receiptImportStatus.state === "success" &&
-                      receiptImportStatus.warnings.map((warning) => (
-                        <Alert severity="warning" key={warning}>
+                      receiptImportStatus.warnings.map((warning, index) => (
+                        <Alert severity="warning" key={`${index}-${warning}`}>
                           {warning}
                         </Alert>
                       ))}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import PersonRoundedIcon from "@mui/icons-material/PersonRounded";
 import PictureAsPdfRoundedIcon from "@mui/icons-material/PictureAsPdfRounded";
 import RemoveCircleOutlineRoundedIcon from "@mui/icons-material/RemoveCircleOutlineRounded";
 import RestartAltRoundedIcon from "@mui/icons-material/RestartAltRounded";
+import UploadFileRoundedIcon from "@mui/icons-material/UploadFileRounded";
 import {
   closestCenter,
   DndContext,
@@ -56,7 +57,15 @@ import {
   Tooltip,
   Typography
 } from "@mui/material";
-import { startTransition, useDeferredValue, useEffect, useState, type ReactNode } from "react";
+import {
+  startTransition,
+  useDeferredValue,
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type ReactNode
+} from "react";
 import { useFieldArray, useForm, useWatch } from "react-hook-form";
 import {
   computeItemPreview,
@@ -79,6 +88,7 @@ import {
   validateStepThree,
   validateStepTwo
 } from "./domain/splitter";
+import type { ReceiptImportItem } from "./receipt-import/types";
 import { clearStoredDraft, loadStoredDraft, storeDraft } from "./storage";
 
 const STEP_LABELS = [
@@ -180,6 +190,13 @@ function App() {
   const [pdfNoticeOpen, setPdfNoticeOpen] = useState(false);
   const [pdfErrorNoticeOpen, setPdfErrorNoticeOpen] = useState(false);
   const [exportPdfPending, setExportPdfPending] = useState(false);
+  const [receiptImportStatus, setReceiptImportStatus] = useState<
+    | { state: "idle" }
+    | { state: "processing"; fileName: string }
+    | { state: "success"; fileName: string; importedCount: number; warnings: string[] }
+    | { state: "error"; message: string }
+  >({ state: "idle" });
+  const receiptInputRef = useRef<HTMLInputElement | null>(null);
 
   const {
     control,
@@ -353,12 +370,38 @@ function App() {
     });
   }
 
+  function resetItems() {
+    const currentValues = getValues();
+
+    reset({
+      ...currentValues,
+      items: []
+    });
+    clearErrors("items");
+    setReceiptImportStatus({ state: "idle" });
+  }
+
   function reorderItems(oldIndex: number, newIndex: number) {
     if (oldIndex === newIndex || newIndex < 0 || newIndex >= items.length) {
       return;
     }
 
     itemsArray.move(oldIndex, newIndex);
+  }
+
+  function appendImportedItems(importedItems: ReceiptImportItem[]) {
+    const currentValues = getValues();
+    const preservedItems = currentValues.items.filter((item) => item.name.trim() || item.price.trim());
+    const mappedItems = importedItems.map((item) => ({
+      ...createEmptyItem(currentValues.participants),
+      name: item.name,
+      price: item.price
+    }));
+
+    reset({
+      ...currentValues,
+      items: [...preservedItems, ...mappedItems]
+    });
   }
 
   function handleItemSubmitFromEnter(index: number) {
@@ -534,6 +577,7 @@ function App() {
     setActiveStep(0);
     setHasUnlockedFullNavigation(false);
     setHasStarted(false);
+    setReceiptImportStatus({ state: "idle" });
     setShowRestoreDialog(false);
   }
 
@@ -543,6 +587,7 @@ function App() {
     setActiveStep(0);
     setHasUnlockedFullNavigation(false);
     setHasStarted(false);
+    setReceiptImportStatus({ state: "idle" });
   }
 
   async function copySummary() {
@@ -585,6 +630,34 @@ function App() {
       setPdfErrorNoticeOpen(true);
     } finally {
       setExportPdfPending(false);
+    }
+  }
+
+  async function handleReceiptFileSelection(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+
+    if (!file) {
+      return;
+    }
+
+    setReceiptImportStatus({ state: "processing", fileName: file.name });
+
+    try {
+      const { importReceipt } = await import("./receipt-import/importReceipt");
+      const result = await importReceipt(file);
+      appendImportedItems(result.items);
+      setReceiptImportStatus({
+        state: "success",
+        fileName: result.fileName,
+        importedCount: result.items.length,
+        warnings: result.warnings.map((warning) => warning.message)
+      });
+    } catch (error) {
+      setReceiptImportStatus({
+        state: "error",
+        message: error instanceof Error ? error.message : "Receipt import failed. Try another file."
+      });
     }
   }
 
@@ -887,14 +960,72 @@ function App() {
 
                 {activeStep === 1 && (
                   <Stack spacing={3}>
-                    <Button
-                      variant="contained"
-                      startIcon={<AddRoundedIcon />}
-                      onClick={addItem}
-                      sx={{ alignSelf: "flex-start" }}
+                    <Stack
+                      direction={{ xs: "column", sm: "row" }}
+                      spacing={1.25}
+                      alignItems={{ sm: "center" }}
+                      justifyContent="space-between"
                     >
-                      Add item
-                    </Button>
+                      <Stack direction={{ xs: "column", sm: "row" }} spacing={1.25}>
+                        <Button
+                          variant="contained"
+                          startIcon={<AddRoundedIcon />}
+                          onClick={addItem}
+                          sx={{ alignSelf: "flex-start" }}
+                        >
+                          Add item
+                        </Button>
+                        <Button
+                          variant="outlined"
+                          startIcon={<UploadFileRoundedIcon />}
+                          onClick={() => receiptInputRef.current?.click()}
+                          disabled={receiptImportStatus.state === "processing"}
+                          sx={{ alignSelf: "flex-start" }}
+                        >
+                          {receiptImportStatus.state === "processing" ? "Importing receipt..." : "Import receipt"}
+                        </Button>
+                      </Stack>
+                      <Button
+                        variant="text"
+                        color="inherit"
+                        startIcon={<RestartAltRoundedIcon />}
+                        onClick={resetItems}
+                        disabled={items.length === 0 || receiptImportStatus.state === "processing"}
+                        sx={{ alignSelf: { xs: "flex-start", sm: "flex-end" } }}
+                      >
+                        Reset items
+                      </Button>
+                      <input
+                        ref={receiptInputRef}
+                        aria-label="Import receipt file"
+                        accept="image/*,.pdf,application/pdf"
+                        type="file"
+                        hidden
+                        onChange={handleReceiptFileSelection}
+                      />
+                    </Stack>
+
+                    {receiptImportStatus.state === "processing" && (
+                      <Alert severity="info">Reading {receiptImportStatus.fileName} and extracting receipt lines.</Alert>
+                    )}
+
+                    {receiptImportStatus.state === "success" && (
+                      <Alert severity="success">
+                        Imported {receiptImportStatus.importedCount} items from {receiptImportStatus.fileName}. Review
+                        and edit anything that needs cleanup.
+                      </Alert>
+                    )}
+
+                    {receiptImportStatus.state === "error" && (
+                      <Alert severity="error">{receiptImportStatus.message}</Alert>
+                    )}
+
+                    {receiptImportStatus.state === "success" &&
+                      receiptImportStatus.warnings.map((warning) => (
+                        <Alert severity="warning" key={warning}>
+                          {warning}
+                        </Alert>
+                      ))}
 
                     {errors.items?.message && <Alert severity="error">{errors.items.message}</Alert>}
 
@@ -920,28 +1051,6 @@ function App() {
                                 disableMoveDown={index === items.length - 1}
                               >
                                 <Stack spacing={1.75}>
-                                  {(item.name.trim() || item.price.trim()) && (
-                                    <Stack
-                                      direction={{ xs: "column", sm: "row" }}
-                                      spacing={{ xs: 0.35, sm: 1 }}
-                                      alignItems={{ sm: "center" }}
-                                    >
-                                      <Typography variant="h6" fontWeight={800}>
-                                        {item.name.trim() || `Item ${index + 1}`}
-                                      </Typography>
-                                      {item.price.trim() && (
-                                        <Typography
-                                          variant="h6"
-                                          fontWeight={800}
-                                          color="primary.main"
-                                          sx={{ letterSpacing: "-0.02em" }}
-                                        >
-                                          {formatMoneyTrailingSymbol(parseMoneyToCents(item.price) ?? 0, currency)}
-                                        </Typography>
-                                      )}
-                                    </Stack>
-                                  )}
-
                                   <Grid container spacing={2}>
                                   <Grid size={{ xs: 12, md: 7 }}>
                                     <TextField
@@ -956,6 +1065,20 @@ function App() {
                                           event.preventDefault();
                                           handleItemSubmitFromEnter(index);
                                         }
+                                      }}
+                                      sx={{
+                                        "& .MuiInputAdornment-root": {
+                                          color: "text.secondary",
+                                          fontWeight: 700
+                                        },
+                                        "& .MuiInputBase-input": {
+                                          fontWeight: 700
+                                        }
+                                      }}
+                                      InputProps={{
+                                        startAdornment: (
+                                          <InputAdornment position="start">#{index + 1}</InputAdornment>
+                                        )
                                       }}
                                     />
                                   </Grid>
@@ -976,6 +1099,11 @@ function App() {
                                         if (event.key === "Enter") {
                                           event.preventDefault();
                                           handleItemSubmitFromEnter(index);
+                                        }
+                                      }}
+                                      sx={{
+                                        "& .MuiInputBase-input": {
+                                          fontWeight: 700
                                         }
                                       }}
                                     />
@@ -1290,9 +1418,6 @@ function App() {
                     >
                       <Box>
                         <Typography variant="h2">Final balances</Typography>
-                        <Typography color="text.secondary">
-                          Total receipt: {formatMoney(settlement.data.totalCents, settlement.data.currency)}
-                        </Typography>
                       </Box>
                       <Stack direction={{ xs: "column", sm: "row" }} spacing={1.25}>
                         <Button
@@ -1336,24 +1461,18 @@ function App() {
                                     justifyContent="space-between"
                                     alignItems={{ md: "center" }}
                                   >
-                                    <Box>
-                                      <Typography variant="overline" color="text.secondary">
-                                        Payer
-                                      </Typography>
-                                      <Typography variant="h4">
-                                        {payer.name}
-                                      </Typography>
-                                      <Typography color="text.secondary">
-                                        This is the person who paid the full receipt and should be reimbursed.
-                                      </Typography>
-                                    </Box>
-                                    <Chip
-                                      label={`Collect ${formatMoney(payer.netCents, settlement.data.currency)}`}
-                                      color="primary"
-                                      variant="outlined"
-                                      sx={{ fontWeight: 800 }}
-                                    />
-                                  </Stack>
+                                      <Box>
+                                        <Typography variant="overline" color="text.secondary">
+                                          Payer
+                                        </Typography>
+                                        <Typography variant="h4">
+                                          {payer.name}
+                                        </Typography>
+                                        <Typography color="text.secondary">
+                                          This is the person who paid the full receipt and should be reimbursed.
+                                        </Typography>
+                                      </Box>
+                                    </Stack>
 
                                   <Grid container spacing={1.5}>
                                     {[
@@ -1366,22 +1485,25 @@ function App() {
                                         label: "Gets back",
                                         value: formatMoney(payer.netCents, settlement.data.currency)
                                       }
-                                    ].map((metric) => (
-                                      <Grid size={{ xs: 12, md: 4 }} key={metric.label}>
-                                        <Box
-                                          sx={{
-                                            p: 1.75,
+                                      ].map((metric) => (
+                                        <Grid size={{ xs: 12, md: 4 }} key={metric.label}>
+                                          <Box
+                                            sx={{
+                                              p: 1.75,
                                             borderRadius: "20px",
                                             bgcolor: alpha("#1D1D1F", 0.03)
                                           }}
-                                        >
-                                          <Typography color="text.secondary">{metric.label}</Typography>
-                                          <Typography variant="h5">
-                                            {metric.value}
-                                          </Typography>
-                                        </Box>
-                                      </Grid>
-                                    ))}
+                                          >
+                                            <Typography color="text.secondary">{metric.label}</Typography>
+                                            <Typography
+                                              variant="h5"
+                                              color={metric.label === "Gets back" ? "primary.main" : undefined}
+                                            >
+                                              {metric.value}
+                                            </Typography>
+                                          </Box>
+                                        </Grid>
+                                      ))}
                                   </Grid>
                                 </Stack>
                               </CardContent>

--- a/src/receipt-import/importReceipt.test.ts
+++ b/src/receipt-import/importReceipt.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { buildLinesFromPdfTextItems } from "./importReceipt";
+
+describe("buildLinesFromPdfTextItems", () => {
+  it("keeps the trailing price on the same line when the last token has hasEOL", () => {
+    const lines = buildLinesFromPdfTextItems([
+      { str: "(C)", transform: [0, 0, 0, 0, 5, 825.25], hasEOL: false },
+      { str: "BOL DIGESTIVE AVEIA CHOCO CNT", transform: [0, 0, 0, 0, 23, 825.25], hasEOL: false },
+      { str: "1,79", transform: [0, 0, 0, 0, 203, 825.25], hasEOL: true },
+      { str: "(C)", transform: [0, 0, 0, 0, 5, 817.75], hasEOL: false },
+      { str: "BOL GULLON AVELA 220G", transform: [0, 0, 0, 0, 23, 817.75], hasEOL: true },
+      { str: "2 X 1,49", transform: [0, 0, 0, 0, 31, 810.25], hasEOL: false },
+      { str: "2,98", transform: [0, 0, 0, 0, 203, 810.25], hasEOL: true }
+    ]);
+
+    expect(lines).toEqual([
+      "(C) BOL DIGESTIVE AVEIA CHOCO CNT 1,79",
+      "(C) BOL GULLON AVELA 220G",
+      "2 X 1,49 2,98"
+    ]);
+  });
+});

--- a/src/receipt-import/importReceipt.test.ts
+++ b/src/receipt-import/importReceipt.test.ts
@@ -10,13 +10,20 @@ describe("buildLinesFromPdfTextItems", () => {
       { str: "(C)", transform: [0, 0, 0, 0, 5, 817.75], hasEOL: false },
       { str: "BOL GULLON AVELA 220G", transform: [0, 0, 0, 0, 23, 817.75], hasEOL: true },
       { str: "2 X 1,49", transform: [0, 0, 0, 0, 31, 810.25], hasEOL: false },
-      { str: "2,98", transform: [0, 0, 0, 0, 203, 810.25], hasEOL: true }
+      { str: "2,98", transform: [0, 0, 0, 0, 203, 810.25], hasEOL: true },
+      { str: "Boundary", transform: [0, 0, 0, 0, 5, 800], hasEOL: false },
+      { str: "Case", transform: [0, 0, 0, 0, 60, 798.5], hasEOL: true },
+      { str: "Split", transform: [0, 0, 0, 0, 5, 790], hasEOL: false },
+      { str: "Case", transform: [0, 0, 0, 0, 60, 788.4999], hasEOL: true }
     ]);
 
     expect(lines).toEqual([
       "(C) BOL DIGESTIVE AVEIA CHOCO CNT 1,79",
       "(C) BOL GULLON AVELA 220G",
-      "2 X 1,49 2,98"
+      "2 X 1,49 2,98",
+      "Boundary Case",
+      "Split",
+      "Case"
     ]);
   });
 });

--- a/src/receipt-import/importReceipt.ts
+++ b/src/receipt-import/importReceipt.ts
@@ -18,24 +18,12 @@ type PdfTextItem = {
   transform?: number[];
 };
 
-async function recognizeCanvas(canvas: HTMLCanvasElement) {
+async function recognizeWithTesseract(input: HTMLCanvasElement | File) {
   const { createWorker } = await import("tesseract.js");
   const worker = await createWorker("eng");
 
   try {
-    const result = await worker.recognize(canvas);
-    return result.data.text;
-  } finally {
-    await worker.terminate();
-  }
-}
-
-async function recognizeImageFile(file: File) {
-  const { createWorker } = await import("tesseract.js");
-  const worker = await createWorker("eng");
-
-  try {
-    const result = await worker.recognize(file);
+    const result = await worker.recognize(input);
     return result.data.text;
   } finally {
     await worker.terminate();
@@ -140,7 +128,7 @@ async function extractOcrTextFromPdf(file: File) {
         viewport
       }).promise;
 
-      pageTexts.push(await recognizeCanvas(canvas));
+      pageTexts.push(await recognizeWithTesseract(canvas));
     }
 
     return pageTexts.join("\n");
@@ -177,12 +165,17 @@ export async function importReceipt(file: File): Promise<ReceiptImportResult> {
       };
     }
   } else {
-    rawText = await recognizeImageFile(file);
+    rawText = await recognizeWithTesseract(file);
     parsed = parseReceiptText(rawText);
   }
 
   if (parsed.items.length === 0) {
-    throw new Error(parsed.warnings[0]?.message ?? "No receipt items could be detected.");
+    const warningSummary = parsed.warnings.map((warning) => warning.message).join(" ");
+    const rawTextPreview = rawText.replace(/\s+/g, " ").trim().slice(0, 160);
+    const diagnosticMessage = warningSummary || "No receipt items could be detected.";
+    const previewSuffix = rawTextPreview ? ` Raw text preview: ${rawTextPreview}` : "";
+
+    throw new Error(`${diagnosticMessage}${previewSuffix}`);
   }
 
   return {

--- a/src/receipt-import/importReceipt.ts
+++ b/src/receipt-import/importReceipt.ts
@@ -1,0 +1,195 @@
+import pdfWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
+import type { ReceiptImportResult } from "./types";
+import { parseReceiptText } from "./parseReceiptText";
+
+declare global {
+  interface Window {
+    __splitBillReceiptImportMock?: (file: File) => Promise<ReceiptImportResult> | ReceiptImportResult;
+  }
+}
+
+function isPdfFile(file: File) {
+  return file.type === "application/pdf" || file.name.toLowerCase().endsWith(".pdf");
+}
+
+type PdfTextItem = {
+  str?: string;
+  hasEOL?: boolean;
+  transform?: number[];
+};
+
+async function recognizeCanvas(canvas: HTMLCanvasElement) {
+  const { createWorker } = await import("tesseract.js");
+  const worker = await createWorker("eng");
+
+  try {
+    const result = await worker.recognize(canvas);
+    return result.data.text;
+  } finally {
+    await worker.terminate();
+  }
+}
+
+async function recognizeImageFile(file: File) {
+  const { createWorker } = await import("tesseract.js");
+  const worker = await createWorker("eng");
+
+  try {
+    const result = await worker.recognize(file);
+    return result.data.text;
+  } finally {
+    await worker.terminate();
+  }
+}
+
+async function loadPdfDocument(file: File) {
+  const pdfjs = await import("pdfjs-dist");
+  pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
+
+  const buffer = await file.arrayBuffer();
+  const task = pdfjs.getDocument({ data: buffer });
+  return task.promise;
+}
+
+function flushPdfLine(lines: string[], tokens: string[]) {
+  if (tokens.length === 0) {
+    return;
+  }
+
+  const nextLine = tokens.join(" ").replace(/\s+/g, " ").trim();
+  if (nextLine) {
+    lines.push(nextLine);
+  }
+  tokens.length = 0;
+}
+
+export function buildLinesFromPdfTextItems(items: PdfTextItem[]) {
+  const lines: string[] = [];
+  const currentTokens: string[] = [];
+  let currentY: number | null = null;
+
+  items.forEach((item) => {
+    const token = item.str?.replace(/\s+/g, " ").trim() ?? "";
+    const itemY = Array.isArray(item.transform) ? item.transform[5] : null;
+    const shouldBreakLine =
+      currentTokens.length > 0 &&
+      typeof itemY === "number" &&
+      typeof currentY === "number" &&
+      Math.abs(itemY - currentY) > 1.5;
+
+    if (shouldBreakLine) {
+      flushPdfLine(lines, currentTokens);
+    }
+
+    if (token) {
+      currentTokens.push(token);
+    }
+
+    if (typeof itemY === "number") {
+      currentY = itemY;
+    }
+
+    if (item.hasEOL) {
+      flushPdfLine(lines, currentTokens);
+      currentY = null;
+    }
+  });
+
+  flushPdfLine(lines, currentTokens);
+  return lines;
+}
+
+async function extractEmbeddedTextFromPdf(file: File) {
+  const document = await loadPdfDocument(file);
+  const pageTexts: string[] = [];
+
+  try {
+    for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber += 1) {
+      const page = await document.getPage(pageNumber);
+      const content = await page.getTextContent();
+      const pageLines = buildLinesFromPdfTextItems(content.items as PdfTextItem[]);
+      pageTexts.push(...pageLines);
+    }
+
+    return pageTexts.join("\n");
+  } finally {
+    await document.destroy();
+  }
+}
+
+async function extractOcrTextFromPdf(file: File) {
+  const document = await loadPdfDocument(file);
+  const pageTexts: string[] = [];
+
+  try {
+    for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber += 1) {
+      const page = await document.getPage(pageNumber);
+      const viewport = page.getViewport({ scale: 2 });
+      const canvas = window.document.createElement("canvas");
+      canvas.width = Math.ceil(viewport.width);
+      canvas.height = Math.ceil(viewport.height);
+      const context = canvas.getContext("2d");
+
+      if (!context) {
+        throw new Error("Could not create canvas context for PDF parsing.");
+      }
+
+      await page.render({
+        canvas,
+        canvasContext: context,
+        viewport
+      }).promise;
+
+      pageTexts.push(await recognizeCanvas(canvas));
+    }
+
+    return pageTexts.join("\n");
+  } finally {
+    await document.destroy();
+  }
+}
+
+export async function importReceipt(file: File): Promise<ReceiptImportResult> {
+  if (window.__splitBillReceiptImportMock) {
+    return Promise.resolve(window.__splitBillReceiptImportMock(file));
+  }
+
+  const source = isPdfFile(file) ? "pdf" : "image";
+  let rawText = "";
+  let parsed: ReturnType<typeof parseReceiptText> = { items: [], warnings: [] };
+
+  if (source === "pdf") {
+    rawText = await extractEmbeddedTextFromPdf(file);
+    parsed = parseReceiptText(rawText);
+
+    if (parsed.items.length === 0) {
+      rawText = await extractOcrTextFromPdf(file);
+      const fallbackParsed = parseReceiptText(rawText);
+      parsed = {
+        ...fallbackParsed,
+        warnings: [
+          {
+            code: "ocr-fallback",
+            message: "Used OCR fallback because the PDF text layer did not yield any probable items."
+          },
+          ...fallbackParsed.warnings
+        ]
+      };
+    }
+  } else {
+    rawText = await recognizeImageFile(file);
+    parsed = parseReceiptText(rawText);
+  }
+
+  if (parsed.items.length === 0) {
+    throw new Error(parsed.warnings[0]?.message ?? "No receipt items could be detected.");
+  }
+
+  return {
+    source,
+    fileName: file.name,
+    rawText,
+    items: parsed.items,
+    warnings: parsed.warnings
+  };
+}

--- a/src/receipt-import/importReceipt.ts
+++ b/src/receipt-import/importReceipt.ts
@@ -129,6 +129,10 @@ async function extractOcrTextFromPdf(file: File) {
       }).promise;
 
       pageTexts.push(await recognizeWithTesseract(canvas));
+      context.clearRect(0, 0, canvas.width, canvas.height);
+      canvas.width = 0;
+      canvas.height = 0;
+      page.cleanup();
     }
 
     return pageTexts.join("\n");

--- a/src/receipt-import/parseReceiptText.test.ts
+++ b/src/receipt-import/parseReceiptText.test.ts
@@ -84,6 +84,15 @@ describe("parseReceiptText", () => {
     ]);
   });
 
+  it("uses quantity times unit price when the wrapped line has no explicit total", () => {
+    const result = parseReceiptText(`
+      (A) MASSA ESPIRAIS MILANEZA 500G
+      2 X 1,04
+    `);
+
+    expect(result.items).toEqual([{ name: "MASSA ESPIRAIS MILANEZA 500G", price: "2.08" }]);
+  });
+
   it("ignores supermarket headers and note lines without treating them as items", () => {
     const result = parseReceiptText(`
       Padaria:
@@ -151,6 +160,15 @@ describe("parseReceiptText", () => {
       (C) BOL DIGESTIVE AVEIA CHOCO CNT 1,79
       Aprox. fim prazo validade
       Continente Pay (**** 3879) 53,09
+    `);
+
+    expect(result.items).toEqual([{ name: "BOL DIGESTIVE AVEIA CHOCO CNT", price: "1.79" }]);
+  });
+
+  it("does not treat tax-prefixed all-caps merchant headers as item descriptions", () => {
+    const result = parseReceiptText(`
+      (C) CONTINENTE BOM DIA
+      (C) BOL DIGESTIVE AVEIA CHOCO CNT 1,79
     `);
 
     expect(result.items).toEqual([{ name: "BOL DIGESTIVE AVEIA CHOCO CNT", price: "1.79" }]);

--- a/src/receipt-import/parseReceiptText.test.ts
+++ b/src/receipt-import/parseReceiptText.test.ts
@@ -60,6 +60,16 @@ describe("parseReceiptText", () => {
     expect(result.warnings.some((warning) => warning.code === "no-items-detected")).toBe(true);
   });
 
+  it("warns on empty input", () => {
+    const result = parseReceiptText("   \n   ");
+
+    expect(result.items).toEqual([]);
+    expect(result.warnings).toContainEqual({
+      code: "no-items-detected",
+      message: "No probable receipt items were detected. Try a clearer photo or edit items manually."
+    });
+  });
+
   it("merges wrapped supermarket item descriptions with quantity continuation lines", () => {
     const result = parseReceiptText(`
       Mercearia Doce:
@@ -93,6 +103,21 @@ describe("parseReceiptText", () => {
     expect(result.items).toEqual([{ name: "Iogurte", price: "3.49" }]);
   });
 
+  it("supports multiple discount keywords while keeping valid items", () => {
+    const result = parseReceiptText(`
+      Iogurte 3,49
+      DESCONTO 1,20
+      OFERTA 0,50
+      TOTAL A PAGAR 1,79
+    `);
+
+    expect(result.items).toEqual([
+      { name: "Iogurte", price: "3.49" },
+      { name: "DESCONTO", price: "-1.20" },
+      { name: "OFERTA", price: "-0.50" }
+    ]);
+  });
+
   it("ignores vat distribution footer rows", () => {
     const result = parseReceiptText(`
       (C) BOL GULLON AVELA 220G 1,49
@@ -117,5 +142,17 @@ describe("parseReceiptText", () => {
       code: "ignored-summary-lines",
       message: "Ignored 3 total or payment lines."
     });
+  });
+
+  it("extracts valid items from mixed receipt noise without absorbing merchant headers", () => {
+    const result = parseReceiptText(`
+      CONTINENTE MONTIJO
+      Fatura Simplificada Original
+      (C) BOL DIGESTIVE AVEIA CHOCO CNT 1,79
+      Aprox. fim prazo validade
+      Continente Pay (**** 3879) 53,09
+    `);
+
+    expect(result.items).toEqual([{ name: "BOL DIGESTIVE AVEIA CHOCO CNT", price: "1.79" }]);
   });
 });

--- a/src/receipt-import/parseReceiptText.test.ts
+++ b/src/receipt-import/parseReceiptText.test.ts
@@ -103,6 +103,16 @@ describe("parseReceiptText", () => {
     expect(result.items).toEqual([{ name: "Pao de forma", price: "2.19" }]);
   });
 
+  it("ignores punctuated footer note keywords such as www and tel", () => {
+    const result = parseReceiptText(`
+      www.continente.pt
+      tel. 21 123 4567
+      Pao de forma 2,19
+    `);
+
+    expect(result.items).toEqual([{ name: "Pao de forma", price: "2.19" }]);
+  });
+
   it("ignores savings-only lines such as poupanca metadata", () => {
     const result = parseReceiptText(`
       Iogurte 3,49

--- a/src/receipt-import/parseReceiptText.test.ts
+++ b/src/receipt-import/parseReceiptText.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { parseReceiptText } from "./parseReceiptText";
+
+describe("parseReceiptText", () => {
+  it("extracts standard item lines with trailing prices", () => {
+    const result = parseReceiptText(`
+      BANANAS 1.99
+      TOMATOES 2.49
+    `);
+
+    expect(result.items).toEqual([
+      { name: "BANANAS", price: "1.99" },
+      { name: "TOMATOES", price: "2.49" }
+    ]);
+  });
+
+  it("turns discount lines into negative rows", () => {
+    const result = parseReceiptText(`
+      Pasta 3.50
+      Promo discount 0.75
+    `);
+
+    expect(result.items).toEqual([
+      { name: "Pasta", price: "3.50" },
+      { name: "Promo discount", price: "-0.75" }
+    ]);
+  });
+
+  it("ignores total and payment lines", () => {
+    const result = parseReceiptText(`
+      Apples 2.00
+      Subtotal 2.00
+      Total 2.00
+      Paid cash 2.00
+    `);
+
+    expect(result.items).toEqual([{ name: "Apples", price: "2.00" }]);
+    expect(result.warnings.some((warning) => warning.code === "ignored-summary-lines")).toBe(true);
+  });
+
+  it("supports mixed decimal separators and thousands cleanup", () => {
+    const result = parseReceiptText(`
+      Olive Oil 1.234,56
+      Cheese 12,30
+    `);
+
+    expect(result.items).toEqual([
+      { name: "Olive Oil", price: "1234.56" },
+      { name: "Cheese", price: "12.30" }
+    ]);
+  });
+
+  it("warns when no probable items are found", () => {
+    const result = parseReceiptText(`
+      TOTAL 8.99
+      VISA 8.99
+    `);
+
+    expect(result.items).toEqual([]);
+    expect(result.warnings.some((warning) => warning.code === "no-items-detected")).toBe(true);
+  });
+
+  it("merges wrapped supermarket item descriptions with quantity continuation lines", () => {
+    const result = parseReceiptText(`
+      Mercearia Doce:
+      (C) BOL GULLON AVELA 220G
+      2 X 1,49 2,98
+      (C) NUGGETS FRANGO CAPITAO IGLO 50U 12,99
+    `);
+
+    expect(result.items).toEqual([
+      { name: "BOL GULLON AVELA 220G", price: "2.98" },
+      { name: "NUGGETS FRANGO CAPITAO IGLO 50U", price: "12.99" }
+    ]);
+  });
+
+  it("ignores supermarket headers and note lines without treating them as items", () => {
+    const result = parseReceiptText(`
+      Padaria:
+      Aprox. fim prazo validade
+      Pao de forma 2,19
+    `);
+
+    expect(result.items).toEqual([{ name: "Pao de forma", price: "2.19" }]);
+  });
+
+  it("ignores savings-only lines such as poupanca metadata", () => {
+    const result = parseReceiptText(`
+      Iogurte 3,49
+      POUPANCA 1,20
+    `);
+
+    expect(result.items).toEqual([{ name: "Iogurte", price: "3.49" }]);
+  });
+
+  it("ignores vat distribution footer rows", () => {
+    const result = parseReceiptText(`
+      (C) BOL GULLON AVELA 220G 1,49
+      6,00% 30 431,83
+      13,00% 1530,20
+      23,00% 155 335 719,10
+    `);
+
+    expect(result.items).toEqual([{ name: "BOL GULLON AVELA 220G", price: "1.49" }]);
+  });
+
+  it("ignores portuguese summary and payment footer blocks", () => {
+    const result = parseReceiptText(`
+      BOL DIGESTIVE AVEIA CHOCO CNT 1,79
+      SUBTOTAL 64,31
+      TOTAL A PAGAR 53,09
+      Continente Pay (**** 3879) 53,09
+    `);
+
+    expect(result.items).toEqual([{ name: "BOL DIGESTIVE AVEIA CHOCO CNT", price: "1.79" }]);
+    expect(result.warnings).toContainEqual({
+      code: "ignored-summary-lines",
+      message: "Ignored 3 total or payment lines."
+    });
+  });
+});

--- a/src/receipt-import/parseReceiptText.ts
+++ b/src/receipt-import/parseReceiptText.ts
@@ -1,0 +1,381 @@
+import type { ReceiptImportItem, ReceiptImportWarning } from "./types";
+
+const SUMMARY_KEYWORDS = [
+  "total",
+  "subtotal",
+  "sub total",
+  "amount due",
+  "balance due",
+  "tax",
+  "vat",
+  "iva",
+  "cash",
+  "change",
+  "payment",
+  "paid",
+  "mastercard",
+  "visa",
+  "debit",
+  "credit",
+  "tender",
+  "mbway",
+  "multibanco",
+  "terminal",
+  "pay",
+  "troco",
+  "a pagar",
+  "talão"
+];
+
+const MODIFIER_KEYWORDS = [
+  "discount",
+  "promo",
+  "coupon",
+  "offer",
+  "desconto"
+];
+
+const IGNORE_MODIFIER_KEYWORDS = ["saving", "savings", "poupanca", "poupa"];
+
+const NOTE_KEYWORDS = [
+  "aprox",
+  "validade",
+  "cliente",
+  "operador",
+  "loja",
+  "morada",
+  "obrigado",
+  "thank you",
+  "www.",
+  "tel.",
+  "telefone",
+  "nif"
+];
+
+const TRAILING_PRICE_PATTERN = /(-?\d[\d\s.,]*[.,]\d{2})\s*$/;
+const QUANTITY_CONTINUATION_PATTERN =
+  /^(?:\d+(?:[.,]\d+)?)\s*[xX]\s+(?<unit>\d[\d.,]*[.,]\d{2})(?:\s+(?<total>-?\d[\d.,]*[.,]\d{2}))?\s*$/;
+
+type ParsedPriceCandidate = {
+  rawPrice: string;
+  namePart: string;
+};
+
+type ClassifiedLine =
+  | { kind: "item"; name: string; amountCents: number }
+  | { kind: "modifier"; name: string; amountCents: number }
+  | { kind: "continuation"; amountCents: number }
+  | { kind: "summary" | "header" | "note" | "description" | "unknown"; text: string };
+
+function normalizeLine(line: string) {
+  return line.replace(/\s+/g, " ").trim();
+}
+
+function stripTaxCodePrefix(line: string) {
+  return normalizeLine(line.replace(/^\([A-Z]\)\s*/, ""));
+}
+
+function hasTaxCodePrefix(line: string) {
+  return /^\([A-Z]\)\s*/.test(line);
+}
+
+function normalizeExtractedPrice(rawPrice: string) {
+  const compact = rawPrice.replace(/\s/g, "");
+  const lastComma = compact.lastIndexOf(",");
+  const lastDot = compact.lastIndexOf(".");
+  const decimalIndex = Math.max(lastComma, lastDot);
+
+  if (decimalIndex < 0) {
+    return compact;
+  }
+
+  const integerPart = compact.slice(0, decimalIndex).replace(/[.,]/g, "");
+  const decimalPart = compact.slice(decimalIndex + 1);
+  return `${integerPart}.${decimalPart}`;
+}
+
+function formatPriceString(amountCents: number) {
+  const absolute = Math.abs(amountCents);
+  const whole = Math.floor(absolute / 100);
+  const cents = (absolute % 100).toString().padStart(2, "0");
+  const sign = amountCents < 0 ? "-" : "";
+
+  return `${sign}${whole}.${cents}`;
+}
+
+function parsePriceToCents(rawPrice: string) {
+  const normalizedPrice = normalizeExtractedPrice(rawPrice);
+  const numericPrice = Number(normalizedPrice);
+  if (!Number.isFinite(numericPrice)) {
+    return null;
+  }
+
+  return Math.round(numericPrice * 100);
+}
+
+function extractTrailingPrice(line: string): ParsedPriceCandidate | null {
+  const match = line.match(TRAILING_PRICE_PATTERN);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    rawPrice: match[1],
+    namePart: normalizeLine(line.slice(0, match.index))
+  };
+}
+
+function cleanItemName(name: string) {
+  return normalizeLine(name.replace(/^\([A-Z]\)\s*/, "").replace(/^[xX]\s+/, ""));
+}
+
+function normalizeKeywordText(text: string) {
+  return text
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase();
+}
+
+function countLetters(text: string) {
+  return (text.match(/[A-Za-zÀ-ÿ]/g) ?? []).length;
+}
+
+function countWords(text: string) {
+  return text.split(/\s+/).filter(Boolean).length;
+}
+
+function hasSummaryKeyword(text: string) {
+  const normalized = normalizeKeywordText(text);
+  return SUMMARY_KEYWORDS.some((keyword) => normalized.includes(keyword));
+}
+
+function hasModifierKeyword(text: string) {
+  const normalized = normalizeKeywordText(text);
+  return MODIFIER_KEYWORDS.some((keyword) => normalized.includes(keyword));
+}
+
+function hasIgnoredModifierKeyword(text: string) {
+  const normalized = normalizeKeywordText(text);
+  return IGNORE_MODIFIER_KEYWORDS.some((keyword) => normalized.includes(keyword));
+}
+
+function hasNoteKeyword(text: string) {
+  const normalized = normalizeKeywordText(text);
+  return NOTE_KEYWORDS.some((keyword) => normalized.includes(keyword));
+}
+
+function isHeaderLine(text: string) {
+  return text.endsWith(":");
+}
+
+function isLikelyNoteLine(text: string) {
+  if (hasNoteKeyword(text)) {
+    return true;
+  }
+
+  return /[.?!]$/.test(text) && text === text.toLowerCase() && countWords(text) >= 3;
+}
+
+function isLikelyDescriptionLine(text: string) {
+  if (!text || isHeaderLine(text) || hasSummaryKeyword(text) || isLikelyNoteLine(text)) {
+    return false;
+  }
+
+  if (countLetters(text) < 3) {
+    return false;
+  }
+
+  return countWords(text) <= 10;
+}
+
+function isLikelySummaryLine(text: string) {
+  if (hasSummaryKeyword(text)) {
+    return true;
+  }
+
+  const numericGroups = text.match(/\d[\d.,]*/g) ?? [];
+  return numericGroups.length >= 3 && countLetters(text) < 8;
+}
+
+function isVatDistributionName(text: string) {
+  return /^\d{1,2}(?:[.,]\d{1,2})?%$/.test(text.trim());
+}
+
+function extractContinuationAmount(line: string) {
+  const normalizedLine = stripTaxCodePrefix(line);
+  const match = normalizedLine.match(QUANTITY_CONTINUATION_PATTERN);
+  if (!match) {
+    return null;
+  }
+
+  const rawPrice = match.groups?.total ?? match.groups?.unit;
+  if (!rawPrice) {
+    return null;
+  }
+
+  return parsePriceToCents(rawPrice);
+}
+
+function classifyUnpricedLine(line: string): ClassifiedLine {
+  const text = stripTaxCodePrefix(line);
+
+  if (!text) {
+    return { kind: "unknown", text };
+  }
+
+  if (isHeaderLine(text)) {
+    return { kind: "header", text };
+  }
+
+  if (isLikelySummaryLine(text)) {
+    return { kind: "summary", text };
+  }
+
+  if (isLikelyNoteLine(text)) {
+    return { kind: "note", text };
+  }
+
+  if (isLikelyDescriptionLine(text)) {
+    return { kind: "description", text };
+  }
+
+  return { kind: "unknown", text };
+}
+
+function classifyPricedLine(line: string): ClassifiedLine {
+  const taxPrefixed = hasTaxCodePrefix(line);
+  const continuationAmount = extractContinuationAmount(line);
+  if (continuationAmount !== null) {
+    return { kind: "continuation", amountCents: continuationAmount };
+  }
+
+  const candidate = extractTrailingPrice(stripTaxCodePrefix(line));
+  if (!candidate) {
+    return classifyUnpricedLine(line);
+  }
+
+  const amountCents = parsePriceToCents(candidate.rawPrice);
+  const name = cleanItemName(candidate.namePart);
+
+  if (amountCents === null || amountCents === 0) {
+    return { kind: "unknown", text: line };
+  }
+
+  if (!name) {
+    return { kind: "summary", text: line };
+  }
+
+  if (isVatDistributionName(name) || hasIgnoredModifierKeyword(name) || isLikelySummaryLine(name)) {
+    return { kind: "summary", text: line };
+  }
+
+  if (hasModifierKeyword(name)) {
+    return {
+      kind: "modifier",
+      name,
+      amountCents: -Math.abs(amountCents)
+    };
+  }
+
+  if (taxPrefixed) {
+    return {
+      kind: "item",
+      name,
+      amountCents
+    };
+  }
+
+  return {
+    kind: "item",
+    name,
+    amountCents
+  };
+}
+
+function mergeDescriptions(pendingDescription: string | null, nextDescription: string) {
+  if (!pendingDescription) {
+    return nextDescription;
+  }
+
+  return normalizeLine(`${pendingDescription} ${nextDescription}`);
+}
+
+function pushItem(items: ReceiptImportItem[], name: string, amountCents: number) {
+  if (!name || amountCents === 0) {
+    return;
+  }
+
+  items.push({
+    name,
+    price: formatPriceString(amountCents)
+  });
+}
+
+export function parseReceiptText(rawText: string) {
+  const warnings: ReceiptImportWarning[] = [];
+  const items: ReceiptImportItem[] = [];
+  const ignoredSummaryLines: string[] = [];
+  let pendingDescription: string | null = null;
+
+  const lines = rawText
+    .split(/\r?\n/)
+    .map(normalizeLine)
+    .filter(Boolean);
+
+  lines.forEach((line) => {
+    const classifiedLine = classifyPricedLine(line);
+
+    switch (classifiedLine.kind) {
+      case "description":
+        pendingDescription = mergeDescriptions(pendingDescription, classifiedLine.text);
+        return;
+      case "continuation":
+        if (pendingDescription) {
+          pushItem(items, pendingDescription, classifiedLine.amountCents);
+          pendingDescription = null;
+        }
+        return;
+      case "item": {
+        const itemName = mergeDescriptions(pendingDescription, classifiedLine.name);
+        pushItem(items, itemName, classifiedLine.amountCents);
+        pendingDescription = null;
+        return;
+      }
+      case "modifier":
+        pushItem(items, classifiedLine.name, classifiedLine.amountCents);
+        pendingDescription = null;
+        return;
+      case "summary":
+        ignoredSummaryLines.push(line);
+        pendingDescription = null;
+        return;
+      case "header":
+      case "note":
+        pendingDescription = null;
+        return;
+      case "unknown":
+        return;
+      default:
+        return;
+    }
+  });
+
+  if (ignoredSummaryLines.length > 0) {
+    warnings.push({
+      code: "ignored-summary-lines",
+      message: `Ignored ${ignoredSummaryLines.length} total or payment lines.`
+    });
+  }
+
+  if (items.length === 0) {
+    warnings.push({
+      code: "no-items-detected",
+      message: "No probable receipt items were detected. Try a clearer photo or edit items manually."
+    });
+  }
+
+  return {
+    items,
+    warnings
+  };
+}

--- a/src/receipt-import/parseReceiptText.ts
+++ b/src/receipt-import/parseReceiptText.ts
@@ -156,6 +156,10 @@ function normalizeKeywordText(text: string) {
     .toLowerCase();
 }
 
+function normalizeKeywordToken(text: string) {
+  return normalizeKeywordText(text).replace(/[^a-z0-9]+/g, " ").trim();
+}
+
 function escapeRegExp(text: string) {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -173,11 +177,16 @@ function hasNormalizedKeyword(text: string, normalizedKeywords: string[]) {
   const normalizedTokens = normalized.split(/[^a-z0-9]+/).filter(Boolean);
 
   return normalizedKeywords.some((keyword) => {
-    if (keyword.includes(" ")) {
-      return new RegExp(`\\b${escapeRegExp(keyword)}\\b`).test(normalized);
+    const normalizedKeyword = normalizeKeywordToken(keyword);
+    if (!normalizedKeyword) {
+      return false;
     }
 
-    return normalizedTokens.includes(keyword);
+    if (normalizedKeyword.includes(" ")) {
+      return new RegExp(`\\b${escapeRegExp(normalizedKeyword)}\\b`).test(normalized);
+    }
+
+    return normalizedTokens.includes(normalizedKeyword);
   });
 }
 
@@ -298,7 +307,6 @@ function classifyUnpricedLine(line: string): ClassifiedLine {
 }
 
 function classifyPricedLine(line: string): ClassifiedLine {
-  const taxPrefixed = hasTaxCodePrefix(line);
   const continuationAmount = extractContinuationAmount(line);
   if (continuationAmount !== null) {
     return { kind: "continuation", amountCents: continuationAmount };
@@ -329,14 +337,6 @@ function classifyPricedLine(line: string): ClassifiedLine {
       kind: "modifier",
       name,
       amountCents: -Math.abs(amountCents)
-    };
-  }
-
-  if (taxPrefixed) {
-    return {
-      kind: "item",
-      name,
-      amountCents
     };
   }
 

--- a/src/receipt-import/parseReceiptText.ts
+++ b/src/receipt-import/parseReceiptText.ts
@@ -74,7 +74,7 @@ const NORMALIZED_HEADER_KEYWORDS = HEADER_KEYWORDS.map((keyword) => normalizeKey
 
 const TRAILING_PRICE_PATTERN = /(-?\d[\d\s.,]*[.,]\d{2})\s*$/;
 const QUANTITY_CONTINUATION_PATTERN =
-  /^(?:\d+(?:[.,]\d+)?)\s*[xX]\s+(?<unit>\d[\d.,]*[.,]\d{2})(?:\s+(?<total>-?\d[\d.,]*[.,]\d{2}))?\s*$/;
+  /^(?<quantity>\d+(?:[.,]\d+)?)\s*[xX]\s+(?<unit>\d[\d.,]*[.,]\d{2})(?:\s+(?<total>-?\d[\d.,]*[.,]\d{2}))?\s*$/;
 
 type ParsedPriceCandidate = {
   rawPrice: string;
@@ -226,11 +226,13 @@ function isLikelyDescriptionLine(line: string, text: string) {
     return false;
   }
 
-  if (hasTaxCodePrefix(line)) {
+  const hasMixedCaseText = /[a-zà-ÿ]/.test(text) && text !== text.toUpperCase();
+
+  if (hasMixedCaseText) {
     return true;
   }
 
-  return /[a-zà-ÿ]/.test(text) && text !== text.toUpperCase();
+  return hasTaxCodePrefix(line) && !hasHeaderKeyword(text);
 }
 
 function isLikelySummaryLine(text: string) {
@@ -253,12 +255,20 @@ function extractContinuationAmount(line: string) {
     return null;
   }
 
-  const rawPrice = match.groups?.total ?? match.groups?.unit;
-  if (!rawPrice) {
+  const rawTotal = match.groups?.total;
+  if (rawTotal) {
+    return parsePriceToCents(rawTotal);
+  }
+
+  const rawQuantity = match.groups?.quantity;
+  const rawUnit = match.groups?.unit;
+  const quantity = rawQuantity ? Number(rawQuantity.replace(",", ".")) : Number.NaN;
+  const unitCents = rawUnit ? parsePriceToCents(rawUnit) : null;
+  if (!Number.isFinite(quantity) || unitCents === null) {
     return null;
   }
 
-  return parsePriceToCents(rawPrice);
+  return Math.round(quantity * unitCents);
 }
 
 function classifyUnpricedLine(line: string): ClassifiedLine {

--- a/src/receipt-import/parseReceiptText.ts
+++ b/src/receipt-import/parseReceiptText.ts
@@ -24,7 +24,7 @@ const SUMMARY_KEYWORDS = [
   "pay",
   "troco",
   "a pagar",
-  "talão"
+  "talao"
 ];
 
 const MODIFIER_KEYWORDS = [
@@ -32,6 +32,7 @@ const MODIFIER_KEYWORDS = [
   "promo",
   "coupon",
   "offer",
+  "oferta",
   "desconto"
 ];
 
@@ -51,6 +52,25 @@ const NOTE_KEYWORDS = [
   "telefone",
   "nif"
 ];
+
+const HEADER_KEYWORDS = [
+  "fatura simplificada",
+  "continente",
+  "hipermercados",
+  "descricao",
+  "valor",
+  "cartao cliente",
+  "atcud",
+  "cupoes"
+];
+
+const NORMALIZED_SUMMARY_KEYWORDS = SUMMARY_KEYWORDS.map((keyword) => normalizeKeywordText(keyword));
+const NORMALIZED_MODIFIER_KEYWORDS = MODIFIER_KEYWORDS.map((keyword) => normalizeKeywordText(keyword));
+const NORMALIZED_IGNORED_MODIFIER_KEYWORDS = IGNORE_MODIFIER_KEYWORDS.map((keyword) =>
+  normalizeKeywordText(keyword)
+);
+const NORMALIZED_NOTE_KEYWORDS = NOTE_KEYWORDS.map((keyword) => normalizeKeywordText(keyword));
+const NORMALIZED_HEADER_KEYWORDS = HEADER_KEYWORDS.map((keyword) => normalizeKeywordText(keyword));
 
 const TRAILING_PRICE_PATTERN = /(-?\d[\d\s.,]*[.,]\d{2})\s*$/;
 const QUANTITY_CONTINUATION_PATTERN =
@@ -136,6 +156,10 @@ function normalizeKeywordText(text: string) {
     .toLowerCase();
 }
 
+function escapeRegExp(text: string) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function countLetters(text: string) {
   return (text.match(/[A-Za-zÀ-ÿ]/g) ?? []).length;
 }
@@ -144,28 +168,41 @@ function countWords(text: string) {
   return text.split(/\s+/).filter(Boolean).length;
 }
 
-function hasSummaryKeyword(text: string) {
+function hasNormalizedKeyword(text: string, normalizedKeywords: string[]) {
   const normalized = normalizeKeywordText(text);
-  return SUMMARY_KEYWORDS.some((keyword) => normalized.includes(keyword));
+  const normalizedTokens = normalized.split(/[^a-z0-9]+/).filter(Boolean);
+
+  return normalizedKeywords.some((keyword) => {
+    if (keyword.includes(" ")) {
+      return new RegExp(`\\b${escapeRegExp(keyword)}\\b`).test(normalized);
+    }
+
+    return normalizedTokens.includes(keyword);
+  });
+}
+
+function hasSummaryKeyword(text: string) {
+  return hasNormalizedKeyword(text, NORMALIZED_SUMMARY_KEYWORDS);
 }
 
 function hasModifierKeyword(text: string) {
-  const normalized = normalizeKeywordText(text);
-  return MODIFIER_KEYWORDS.some((keyword) => normalized.includes(keyword));
+  return hasNormalizedKeyword(text, NORMALIZED_MODIFIER_KEYWORDS);
 }
 
 function hasIgnoredModifierKeyword(text: string) {
-  const normalized = normalizeKeywordText(text);
-  return IGNORE_MODIFIER_KEYWORDS.some((keyword) => normalized.includes(keyword));
+  return hasNormalizedKeyword(text, NORMALIZED_IGNORED_MODIFIER_KEYWORDS);
 }
 
 function hasNoteKeyword(text: string) {
-  const normalized = normalizeKeywordText(text);
-  return NOTE_KEYWORDS.some((keyword) => normalized.includes(keyword));
+  return hasNormalizedKeyword(text, NORMALIZED_NOTE_KEYWORDS);
+}
+
+function hasHeaderKeyword(text: string) {
+  return hasNormalizedKeyword(text, NORMALIZED_HEADER_KEYWORDS);
 }
 
 function isHeaderLine(text: string) {
-  return text.endsWith(":");
+  return text.endsWith(":") || hasHeaderKeyword(text);
 }
 
 function isLikelyNoteLine(text: string) {
@@ -176,7 +213,7 @@ function isLikelyNoteLine(text: string) {
   return /[.?!]$/.test(text) && text === text.toLowerCase() && countWords(text) >= 3;
 }
 
-function isLikelyDescriptionLine(text: string) {
+function isLikelyDescriptionLine(line: string, text: string) {
   if (!text || isHeaderLine(text) || hasSummaryKeyword(text) || isLikelyNoteLine(text)) {
     return false;
   }
@@ -185,7 +222,15 @@ function isLikelyDescriptionLine(text: string) {
     return false;
   }
 
-  return countWords(text) <= 10;
+  if (countWords(text) > 10) {
+    return false;
+  }
+
+  if (hasTaxCodePrefix(line)) {
+    return true;
+  }
+
+  return /[a-zà-ÿ]/.test(text) && text !== text.toUpperCase();
 }
 
 function isLikelySummaryLine(text: string) {
@@ -235,7 +280,7 @@ function classifyUnpricedLine(line: string): ClassifiedLine {
     return { kind: "note", text };
   }
 
-  if (isLikelyDescriptionLine(text)) {
+  if (isLikelyDescriptionLine(line, text)) {
     return { kind: "description", text };
   }
 

--- a/src/receipt-import/types.ts
+++ b/src/receipt-import/types.ts
@@ -1,0 +1,17 @@
+export type ReceiptImportItem = {
+  name: string;
+  price: string;
+};
+
+export type ReceiptImportWarning = {
+  code: string;
+  message: string;
+};
+
+export type ReceiptImportResult = {
+  source: "image" | "pdf";
+  fileName: string;
+  rawText: string;
+  items: ReceiptImportItem[];
+  warnings: ReceiptImportWarning[];
+};

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -1,6 +1,20 @@
 import { expect, test } from "@playwright/test";
 
 test("splits a simple grocery receipt", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.clear();
+    window.__splitBillReceiptImportMock = async () => ({
+      source: "image",
+      fileName: "receipt.png",
+      rawText: "Apples 2.49\nBread 1.20",
+      items: [
+        { name: "Apples", price: "2.49" },
+        { name: "Bread", price: "1.20" }
+      ],
+      warnings: [{ code: "ignored-summary-lines", message: "Ignored 1 total or payment lines." }]
+    });
+  });
+
   await page.goto("/");
 
   await page.getByRole("button", { name: "Start splitting" }).click();
@@ -11,8 +25,19 @@ test("splits a simple grocery receipt", async ({ page }) => {
 
   await page.getByRole("button", { name: "Continue" }).last().click();
   await page.getByRole("button", { name: "Add item" }).last().click();
-  await page.getByLabel("Item name").fill("Milk");
-  await page.getByLabel("Price").fill("5.00");
+  await page.getByRole("textbox", { name: "Item name" }).fill("Milk");
+  await page.getByRole("textbox", { name: "Price" }).fill("5.00");
+  const fileChooserPromise = page.waitForEvent("filechooser");
+  await page.getByRole("button", { name: "Import receipt" }).click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles({
+    name: "receipt.png",
+    mimeType: "image/png",
+    buffer: Buffer.from("mock-receipt")
+  });
+  await expect(page.getByText(/Imported 2 items from receipt\.png/)).toBeVisible();
+  await expect(page.getByRole("textbox", { name: "Item name" }).nth(1)).toHaveValue("Apples");
+  await expect(page.getByRole("textbox", { name: "Item name" }).nth(2)).toHaveValue("Bread");
 
   await page.getByRole("button", { name: "Continue" }).last().click();
   await expect(page.getByText(/2\.50/).first()).toBeVisible();
@@ -20,7 +45,8 @@ test("splits a simple grocery receipt", async ({ page }) => {
 
   await expect(page.getByText("Final balances")).toBeVisible();
   await expect(page.getByText("Bruno")).toBeVisible();
-  await expect(page.getByText(/Total receipt: .*5\.00/)).toBeVisible();
+  await expect(page.getByRole("button", { name: "Copy summary" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Export PDF" })).toBeVisible();
 
   const downloadPromise = page.waitForEvent("download");
   await page.getByRole("button", { name: "Export PDF" }).click();


### PR DESCRIPTION
## Summary
- add a Step 2 receipt import flow for images and PDFs
- parse supermarket receipts with PDF text extraction first and OCR fallback only when needed
- tighten receipt parsing for wrapped item lines, VAT footer rows, savings metadata, and Step 2 item-management UX

## Testing
- npm run lint
- npm run test:run
- npm run build
- npm run test:e2e -- --output=./playwright-results-receipt-import