### PR TITLE
feat: add ai and paste item imports

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -11,6 +11,9 @@ const { exportSettlementPdfMock, importReceiptMock } = vi.hoisted(() => ({
   importReceiptMock: vi.fn()
 }));
 
+const clipboardWriteTextMock = vi.fn();
+const windowOpenMock = vi.fn();
+
 vi.mock("./pdf/exportSettlementPdf", () => ({
   exportSettlementPdf: exportSettlementPdfMock
 }));
@@ -53,6 +56,19 @@ describe("App", () => {
     window.localStorage.clear();
     exportSettlementPdfMock.mockReset();
     importReceiptMock.mockReset();
+    clipboardWriteTextMock.mockReset();
+    clipboardWriteTextMock.mockResolvedValue(undefined);
+    windowOpenMock.mockReset();
+    Object.defineProperty(window.navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: clipboardWriteTextMock
+      }
+    });
+    Object.defineProperty(window, "open", {
+      configurable: true,
+      value: windowOpenMock
+    });
   });
 
   afterEach(() => {
@@ -140,7 +156,9 @@ describe("App", () => {
     15000
   );
 
-  it("removes a trailing empty item on enter and advances to the split grid", async () => {
+  it(
+    "removes a trailing empty item on enter and advances to the split grid",
+    async () => {
     const user = userEvent.setup();
     renderApp();
 
@@ -161,7 +179,9 @@ describe("App", () => {
 
     expect(getStepButton("Go to step 3: Consumption grid", false)).toHaveAttribute("aria-current", "step");
     expect(screen.getAllByText(/2\.50/).length).toBeGreaterThan(0);
-  });
+    },
+    15000
+  );
 
   it("allows direct step navigation only within the unlocked range", async () => {
     const user = userEvent.setup();
@@ -173,9 +193,9 @@ describe("App", () => {
     expect(screen.getByLabelText("Add participant")).toBeInTheDocument();
     expect(disabledStep3).toHaveAttribute("aria-disabled", "true");
 
-    await user.click(getStepButton("Go to step 2: Consumption", false));
+    await user.click(getStepButton("Go to step 2: Items & prices", false));
     expect(await screen.findAllByRole("button", { name: "Add item" })).not.toHaveLength(0);
-    expect(getStepButton("Go to step 2: Consumption", false)).toHaveAttribute("aria-current", "step");
+    expect(getStepButton("Go to step 2: Items & prices", false)).toHaveAttribute("aria-current", "step");
 
     await user.click(getStepButton("Go to step 1: People & payer", false));
     expect(getStepButton("Go to step 1: People & payer", false)).toHaveAttribute("aria-current", "step");
@@ -197,7 +217,9 @@ describe("App", () => {
     expect(screen.queryByText("Quick flow")).not.toBeInTheDocument();
   });
 
-  it("shows export pdf in results and exposes a loading state while exporting", async () => {
+  it(
+    "shows export pdf in results and exposes a loading state while exporting",
+    async () => {
     let resolveExport = () => {};
     exportSettlementPdfMock.mockReturnValueOnce(
       new Promise<void>((resolve) => {
@@ -230,7 +252,9 @@ describe("App", () => {
       expect(screen.getByRole("button", { name: "Export PDF" })).toBeEnabled();
     });
     expect(await screen.findByText("PDF exported.")).toBeInTheDocument();
-  });
+    },
+    15000
+  );
 
   it("imports a receipt in step 2 and appends editable items", async () => {
     importReceiptMock.mockResolvedValueOnce({
@@ -257,6 +281,7 @@ describe("App", () => {
 
     const file = new File(["mock"], "receipt.png", { type: "image/png" });
     await user.upload(screen.getByLabelText("Import receipt file"), file);
+    await user.click(screen.getByRole("button", { name: "Apply import" }));
 
     expect(importReceiptMock).toHaveBeenCalledTimes(1);
     expect(await screen.findByText(/Imported 2 items from receipt\.png/)).toBeInTheDocument();
@@ -265,6 +290,111 @@ describe("App", () => {
     expect(screen.getByDisplayValue("Bread")).toBeInTheDocument();
     expect(screen.getByText("Ignored 1 total or payment lines.")).toBeInTheDocument();
   });
+
+  it("opens provider handoff, launches the selected provider, and moves into paste mode", async () => {
+    const user = userEvent.setup();
+    renderApp();
+
+    await user.click(screen.getByRole("button", { name: "Start splitting" }));
+    await addParticipant(user, "Ana");
+    await addParticipant(user, "Bruno");
+    await user.click(getContinueButton());
+
+    await user.click(screen.getByRole("button", { name: "Ask AI" }));
+    expect(screen.getByDisplayValue(/Read the uploaded grocery receipt/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "ChatGPT" }));
+
+    expect(windowOpenMock).toHaveBeenCalledWith("https://chatgpt.com/", "_blank", "noopener,noreferrer");
+    expect(screen.queryByRole("button", { name: "Copy prompt" })).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Pasted items")).toBeInTheDocument();
+  });
+
+  it("opens the paste dialog after manually copying the ai prompt", async () => {
+    const user = userEvent.setup();
+    renderApp();
+
+    await user.click(screen.getByRole("button", { name: "Start splitting" }));
+    await addParticipant(user, "Ana");
+    await addParticipant(user, "Bruno");
+    await user.click(getContinueButton());
+
+    await user.click(screen.getByRole("button", { name: "Ask AI" }));
+    expect(screen.getByText("Expected answer format")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy prompt" })).toBeInTheDocument();
+    expect(screen.getByDisplayValue(/Read the uploaded grocery receipt/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Copy prompt" }));
+
+    expect(screen.queryByRole("button", { name: "Copy prompt" })).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Pasted items")).toBeInTheDocument();
+  });
+
+  it("does not open the paste dialog when the ai handoff dialog is closed normally", async () => {
+    const user = userEvent.setup();
+    renderApp();
+
+    await user.click(screen.getByRole("button", { name: "Start splitting" }));
+    await addParticipant(user, "Ana");
+    await addParticipant(user, "Bruno");
+    await user.click(getContinueButton());
+
+    await user.click(screen.getByRole("button", { name: "Ask AI" }));
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Copy prompt" })).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Pasted items")).not.toBeInTheDocument();
+    });
+  });
+
+  it("clears the pasted input with the reset action", async () => {
+    const user = userEvent.setup();
+    renderApp();
+
+    await user.click(screen.getByRole("button", { name: "Start splitting" }));
+    await addParticipant(user, "Ana");
+    await addParticipant(user, "Bruno");
+    await user.click(getContinueButton());
+
+    await user.click(screen.getByRole("button", { name: "Paste list" }));
+    const pastedItemsInput = screen.getByLabelText("Pasted items");
+    await user.type(pastedItemsInput, "Bananas - 2.49");
+
+    expect(screen.getByRole("button", { name: "Reset" })).toBeEnabled();
+    await user.click(screen.getByRole("button", { name: "Reset" }));
+
+    expect(screen.getByLabelText("Pasted items")).toHaveValue("");
+    expect(screen.getByRole("button", { name: "Reset" })).toBeDisabled();
+  });
+
+  it(
+    "parses pasted items and can replace the existing item list",
+    async () => {
+    const user = userEvent.setup();
+    renderApp();
+
+    await user.click(screen.getByRole("button", { name: "Start splitting" }));
+    await addParticipant(user, "Ana");
+    await addParticipant(user, "Bruno");
+    await user.click(getContinueButton());
+    await user.click(getAddItemButton());
+    await user.type(screen.getByLabelText("Item name"), "Milk");
+    await user.type(screen.getByLabelText("Price"), "5.00");
+
+    await user.click(screen.getByRole("button", { name: "Paste list" }));
+    await user.type(screen.getByLabelText("Pasted items"), "Bananas - 2.49{enter}Bread,1.20");
+    expect(screen.getByText(/Parsed 2 items and ignored 0 lines/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Import pasted list" }));
+    await user.click(screen.getByRole("radio", { name: "Replace current items" }));
+    await user.click(screen.getByRole("button", { name: "Apply import" }));
+
+    expect(screen.queryByDisplayValue("Milk")).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue("Bananas")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Bread")).toBeInTheDocument();
+    expect(await screen.findByText(/Imported 2 items from pasted list/)).toBeInTheDocument();
+    },
+    15000
+  );
 
   it(
     "resets all step 2 items at once",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,12 +5,14 @@ import AutorenewRoundedIcon from "@mui/icons-material/AutorenewRounded";
 import CheckCircleRoundedIcon from "@mui/icons-material/CheckCircleRounded";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import ContentCopyRoundedIcon from "@mui/icons-material/ContentCopyRounded";
+import ContentPasteRoundedIcon from "@mui/icons-material/ContentPasteRounded";
 import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
 import KeyboardArrowDownRoundedIcon from "@mui/icons-material/KeyboardArrowDownRounded";
 import KeyboardArrowUpRoundedIcon from "@mui/icons-material/KeyboardArrowUpRounded";
 import PaidRoundedIcon from "@mui/icons-material/PaidRounded";
 import PersonRoundedIcon from "@mui/icons-material/PersonRounded";
 import PictureAsPdfRoundedIcon from "@mui/icons-material/PictureAsPdfRounded";
+import PsychologyAltRoundedIcon from "@mui/icons-material/PsychologyAltRounded";
 import RemoveCircleOutlineRoundedIcon from "@mui/icons-material/RemoveCircleOutlineRounded";
 import RestartAltRoundedIcon from "@mui/icons-material/RestartAltRounded";
 import UploadFileRoundedIcon from "@mui/icons-material/UploadFileRounded";
@@ -44,11 +46,14 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  FormControlLabel,
   Grid,
   IconButton,
   InputAdornment,
   LinearProgress,
   MenuItem,
+  Radio,
+  RadioGroup,
   Snackbar,
   Stack,
   TextField,
@@ -88,12 +93,14 @@ import {
   validateStepThree,
   validateStepTwo
 } from "./domain/splitter";
+import { buildReceiptLlmPrompt, getReceiptLlmProviderUrl, type LlmProvider } from "./receipt-import/llmHandoff";
+import { parsePastedItems } from "./receipt-import/parsePastedItems";
 import type { ReceiptImportItem } from "./receipt-import/types";
 import { clearStoredDraft, loadStoredDraft, storeDraft } from "./storage";
 
 const STEP_LABELS = [
   "People & payer",
-  "Consumption",
+  "Items & prices",
   "Consumption grid",
   "Results"
 ] as const;
@@ -187,9 +194,19 @@ function App() {
   const [showRestoreDialog, setShowRestoreDialog] = useState(Boolean(storedDraft));
   const [saveNoticeOpen, setSaveNoticeOpen] = useState(false);
   const [copyNoticeOpen, setCopyNoticeOpen] = useState(false);
+  const [copiedLlmPromptNoticeOpen, setCopiedLlmPromptNoticeOpen] = useState(false);
+  const [llmPromptErrorNoticeOpen, setLlmPromptErrorNoticeOpen] = useState(false);
   const [pdfNoticeOpen, setPdfNoticeOpen] = useState(false);
   const [pdfErrorNoticeOpen, setPdfErrorNoticeOpen] = useState(false);
   const [exportPdfPending, setExportPdfPending] = useState(false);
+  const [pasteDialogOpen, setPasteDialogOpen] = useState(false);
+  const [aiDialogOpen, setAiDialogOpen] = useState(false);
+  const [importApplyDialogOpen, setImportApplyDialogOpen] = useState(false);
+  const [importApplyMode, setImportApplyMode] = useState<"append" | "replace">("append");
+  const [pasteInput, setPasteInput] = useState("");
+  const [pendingImportedItems, setPendingImportedItems] = useState<ReceiptImportItem[]>([]);
+  const [pendingImportWarnings, setPendingImportWarnings] = useState<string[]>([]);
+  const [pendingImportSourceLabel, setPendingImportSourceLabel] = useState("");
   const [receiptImportStatus, setReceiptImportStatus] = useState<
     | { state: "idle" }
     | { state: "processing"; fileName: string }
@@ -197,6 +214,7 @@ function App() {
     | { state: "error"; message: string }
   >({ state: "idle" });
   const receiptInputRef = useRef<HTMLInputElement | null>(null);
+  const llmPrompt = buildReceiptLlmPrompt();
 
   const {
     control,
@@ -389,9 +407,12 @@ function App() {
     itemsArray.move(oldIndex, newIndex);
   }
 
-  function appendImportedItems(importedItems: ReceiptImportItem[]) {
+  function applyImportedItems(importedItems: ReceiptImportItem[], mode: "append" | "replace") {
     const currentValues = getValues();
-    const preservedItems = currentValues.items.filter((item) => item.name.trim() || item.price.trim());
+    const preservedItems =
+      mode === "append"
+        ? currentValues.items.filter((item) => item.name.trim() || item.price.trim())
+        : [];
     const mappedItems = importedItems.map((item) => ({
       ...createEmptyItem(currentValues.participants),
       name: item.name,
@@ -402,6 +423,37 @@ function App() {
       ...currentValues,
       items: [...preservedItems, ...mappedItems]
     });
+  }
+
+  function queueImportedItems(importedItems: ReceiptImportItem[], warnings: string[], sourceLabel: string) {
+    setReceiptImportStatus({ state: "idle" });
+    setPendingImportedItems(importedItems);
+    setPendingImportWarnings(warnings);
+    setPendingImportSourceLabel(sourceLabel);
+    setImportApplyMode("append");
+    setImportApplyDialogOpen(true);
+  }
+
+  function confirmImportApply() {
+    applyImportedItems(pendingImportedItems, importApplyMode);
+    setImportApplyDialogOpen(false);
+    setReceiptImportStatus({
+      state: "success",
+      fileName: pendingImportSourceLabel,
+      importedCount: pendingImportedItems.length,
+      warnings: pendingImportWarnings
+    });
+    setPendingImportedItems([]);
+    setPendingImportWarnings([]);
+    setPendingImportSourceLabel("");
+  }
+
+  function closeImportApplyDialog() {
+    setImportApplyDialogOpen(false);
+    setReceiptImportStatus({ state: "idle" });
+    setPendingImportedItems([]);
+    setPendingImportWarnings([]);
+    setPendingImportSourceLabel("");
   }
 
   function handleItemSubmitFromEnter(index: number) {
@@ -646,13 +698,11 @@ function App() {
     try {
       const { importReceipt } = await import("./receipt-import/importReceipt");
       const result = await importReceipt(file);
-      appendImportedItems(result.items);
-      setReceiptImportStatus({
-        state: "success",
-        fileName: result.fileName,
-        importedCount: result.items.length,
-        warnings: result.warnings.map((warning) => warning.message)
-      });
+      queueImportedItems(
+        result.items,
+        result.warnings.map((warning) => warning.message),
+        result.fileName
+      );
     } catch (error) {
       setReceiptImportStatus({
         state: "error",
@@ -661,6 +711,53 @@ function App() {
     }
   }
 
+  async function writeLlmPromptToClipboard() {
+    await navigator.clipboard.writeText(llmPrompt);
+    setCopiedLlmPromptNoticeOpen(true);
+    setLlmPromptErrorNoticeOpen(false);
+  }
+
+  async function launchLlmHandoff(provider: LlmProvider) {
+    window.open(getReceiptLlmProviderUrl(provider), "_blank", "noopener,noreferrer");
+
+    try {
+      await writeLlmPromptToClipboard();
+    } catch {
+      setLlmPromptErrorNoticeOpen(true);
+    }
+
+    setAiDialogOpen(false);
+    setPasteDialogOpen(true);
+  }
+
+  async function copyLlmPrompt() {
+    try {
+      await writeLlmPromptToClipboard();
+    } catch {
+      setLlmPromptErrorNoticeOpen(true);
+    }
+
+    setAiDialogOpen(false);
+    setPasteDialogOpen(true);
+  }
+
+  function handlePastePreviewImport() {
+    const result = parsePastedItems(pasteInput);
+
+    if (result.items.length === 0) {
+      setReceiptImportStatus({
+        state: "error",
+        message: result.warnings[0]?.message ?? "No valid items were detected in the pasted text."
+      });
+      return;
+    }
+
+    setPasteDialogOpen(false);
+    setPasteInput("");
+    queueImportedItems(result.items, result.warnings.map((warning) => warning.message), "pasted list");
+  }
+
+  const parsedPasteResult = parsePastedItems(pasteInput);
   const settlement = computeSettlement(deferredValues);
 
   return (
@@ -983,6 +1080,22 @@ function App() {
                           sx={{ alignSelf: "flex-start" }}
                         >
                           {receiptImportStatus.state === "processing" ? "Importing receipt..." : "Import receipt"}
+                        </Button>
+                        <Button
+                          variant="outlined"
+                          startIcon={<PsychologyAltRoundedIcon />}
+                          onClick={() => setAiDialogOpen(true)}
+                          sx={{ alignSelf: "flex-start" }}
+                        >
+                          Ask AI
+                        </Button>
+                        <Button
+                          variant="outlined"
+                          startIcon={<ContentPasteRoundedIcon />}
+                          onClick={() => setPasteDialogOpen(true)}
+                          sx={{ alignSelf: "flex-start" }}
+                        >
+                          Paste list
                         </Button>
                       </Stack>
                       <Button
@@ -1593,6 +1706,120 @@ function App() {
         </DialogActions>
       </Dialog>
 
+      <Dialog open={aiDialogOpen} onClose={() => setAiDialogOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Ask ChatGPT, Claude, or Gemini</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2.5} sx={{ pt: 1 }}>
+            <Typography color="text.secondary">
+              We copy the prompt for you and open the provider in a new tab. Upload the receipt there, then paste
+              the extracted item list back here.
+            </Typography>
+            <Stack direction={{ xs: "column", sm: "row" }} spacing={1.25}>
+              <Button variant="contained" onClick={() => launchLlmHandoff("chatgpt")}>
+                ChatGPT
+              </Button>
+              <Button variant="contained" onClick={() => launchLlmHandoff("claude")}>
+                Claude
+              </Button>
+              <Button variant="contained" onClick={() => launchLlmHandoff("gemini")}>
+                Gemini
+              </Button>
+            </Stack>
+            <Card variant="outlined">
+              <CardContent>
+                <Stack spacing={0.75}>
+                  <Typography variant="subtitle2">Expected answer format</Typography>
+                  <Typography color="text.secondary">One line per item, using:</Typography>
+                  <Typography sx={{ fontFamily: "monospace", fontWeight: 700 }}>Item name - 2.49</Typography>
+                </Stack>
+              </CardContent>
+            </Card>
+            <TextField
+              label="Prompt"
+              value={llmPrompt}
+              multiline
+              minRows={8}
+              InputProps={{ readOnly: true }}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={copyLlmPrompt}>Copy prompt</Button>
+          <Button onClick={() => setAiDialogOpen(false)}>Close</Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={pasteDialogOpen} onClose={() => setPasteDialogOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Paste item list</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2.5} sx={{ pt: 1 }}>
+            <Typography color="text.secondary">
+              Paste one item per line. The easiest format is <strong>Bananas - 2.49</strong>.
+            </Typography>
+            <TextField
+              label="Pasted items"
+              value={pasteInput}
+              onChange={(event) => setPasteInput(event.target.value)}
+              multiline
+              minRows={10}
+              placeholder={"Bananas - 2.49\nMilk - 3.40\nBread - 1.20"}
+            />
+            <Card variant="outlined">
+              <CardContent>
+                <Stack spacing={0.75}>
+                  <Typography variant="subtitle2">Accepted formats</Typography>
+                  <Typography color="text.secondary">Bananas - 2.49</Typography>
+                  <Typography color="text.secondary">1. Bananas - 2,49€</Typography>
+                  <Typography color="text.secondary">Bananas: 2.49</Typography>
+                  <Typography color="text.secondary">Bananas,2.49</Typography>
+                </Stack>
+              </CardContent>
+            </Card>
+            {pasteInput.trim() && (
+              <Alert severity={parsedPasteResult.items.length > 0 ? "info" : "warning"}>
+                Parsed {parsedPasteResult.items.length} item{parsedPasteResult.items.length === 1 ? "" : "s"} and
+                ignored {parsedPasteResult.ignoredLines.length} line{parsedPasteResult.ignoredLines.length === 1 ? "" : "s"}.
+                {parsedPasteResult.ignoredLines.length > 0 && (
+                  <> First ignored: {parsedPasteResult.ignoredLines.slice(0, 3).join(" | ")}</>
+                )}
+              </Alert>
+            )}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPasteInput("")} disabled={!pasteInput.trim()}>
+            Reset
+          </Button>
+          <Button onClick={() => setPasteDialogOpen(false)}>Cancel</Button>
+          <Button variant="contained" onClick={handlePastePreviewImport}>
+            Import pasted list
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={importApplyDialogOpen} onClose={closeImportApplyDialog} maxWidth="xs" fullWidth>
+        <DialogTitle>How should we apply these items?</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ pt: 1 }}>
+            <Typography color="text.secondary">
+              {pendingImportSourceLabel
+                ? `We found ${pendingImportedItems.length} item${pendingImportedItems.length === 1 ? "" : "s"} from ${pendingImportSourceLabel}.`
+                : `We found ${pendingImportedItems.length} item${pendingImportedItems.length === 1 ? "" : "s"}.`}
+            </Typography>
+            <RadioGroup value={importApplyMode} onChange={(_, value) => setImportApplyMode(value as "append" | "replace")}>
+              <FormControlLabel value="append" control={<Radio />} label="Append to current items" />
+              <FormControlLabel value="replace" control={<Radio />} label="Replace current items" />
+            </RadioGroup>
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeImportApplyDialog}>Cancel</Button>
+          <Button variant="contained" onClick={confirmImportApply}>
+            Apply import
+          </Button>
+        </DialogActions>
+      </Dialog>
+
       <Snackbar open={saveNoticeOpen} autoHideDuration={3500} onClose={() => setSaveNoticeOpen(false)}>
         <Alert severity="success" variant="filled">
           Draft restored.
@@ -1602,6 +1829,26 @@ function App() {
       <Snackbar open={copyNoticeOpen} autoHideDuration={3000} onClose={() => setCopyNoticeOpen(false)}>
         <Alert severity="success" variant="filled">
           Summary copied.
+        </Alert>
+      </Snackbar>
+
+      <Snackbar
+        open={copiedLlmPromptNoticeOpen}
+        autoHideDuration={3000}
+        onClose={() => setCopiedLlmPromptNoticeOpen(false)}
+      >
+        <Alert severity="success" variant="filled">
+          Prompt copied.
+        </Alert>
+      </Snackbar>
+
+      <Snackbar
+        open={llmPromptErrorNoticeOpen}
+        autoHideDuration={4000}
+        onClose={() => setLlmPromptErrorNoticeOpen(false)}
+      >
+        <Alert severity="warning" variant="filled">
+          Could not copy the prompt automatically. Use the Copy prompt button.
         </Alert>
       </Snackbar>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,7 @@ import {
   startTransition,
   useDeferredValue,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type ChangeEvent,
@@ -757,7 +758,7 @@ function App() {
     queueImportedItems(result.items, result.warnings.map((warning) => warning.message), "pasted list");
   }
 
-  const parsedPasteResult = parsePastedItems(pasteInput);
+  const parsedPasteResult = useMemo(() => parsePastedItems(pasteInput), [pasteInput]);
   const settlement = computeSettlement(deferredValues);
 
   return (

--- a/src/receipt-import/llmHandoff.test.ts
+++ b/src/receipt-import/llmHandoff.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { buildReceiptLlmPrompt, getReceiptLlmProviderUrl } from "./llmHandoff";
+
+describe("llmHandoff", () => {
+  it("builds a strict prompt for receipt extraction", () => {
+    const prompt = buildReceiptLlmPrompt();
+
+    expect(prompt).toContain("Item name - 2.49");
+    expect(prompt).toContain("Exclude totals, subtotals, taxes, VAT summaries, payment lines");
+    expect(prompt).toContain("Do not add commentary, numbering, markdown, tables, or explanations.");
+  });
+
+  it("maps supported providers to stable launch urls", () => {
+    expect(getReceiptLlmProviderUrl("chatgpt")).toBe("https://chatgpt.com/");
+    expect(getReceiptLlmProviderUrl("claude")).toBe("https://claude.ai/");
+    expect(getReceiptLlmProviderUrl("gemini")).toBe("https://gemini.google.com/app");
+  });
+});

--- a/src/receipt-import/llmHandoff.ts
+++ b/src/receipt-import/llmHandoff.ts
@@ -1,0 +1,26 @@
+export type LlmProvider = "chatgpt" | "claude" | "gemini";
+
+const PROVIDER_URLS: Record<LlmProvider, string> = {
+  chatgpt: "https://chatgpt.com/",
+  claude: "https://claude.ai/",
+  gemini: "https://gemini.google.com/app"
+};
+
+export function getReceiptLlmProviderUrl(provider: LlmProvider) {
+  return PROVIDER_URLS[provider];
+}
+
+export function buildReceiptLlmPrompt() {
+  return [
+    "Read the uploaded grocery receipt and extract only the purchased receipt items.",
+    "Return the result in this exact format, one item per line:",
+    "Item name - 2.49",
+    "",
+    "Rules:",
+    "- Keep only real purchasable items.",
+    "- Exclude totals, subtotals, taxes, VAT summaries, payment lines, loyalty-card savings, discounts from another card, headers, and notes.",
+    "- Do not add commentary, numbering, markdown, tables, or explanations.",
+    "- Use a plain decimal number for the price.",
+    "- If the receipt uses comma decimals, convert them to dot decimals."
+  ].join("\n");
+}

--- a/src/receipt-import/parsePastedItems.test.ts
+++ b/src/receipt-import/parsePastedItems.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { parsePastedItems } from "./parsePastedItems";
+
+describe("parsePastedItems", () => {
+  it("accepts friendly plain text lines", () => {
+    const result = parsePastedItems(`
+      Bananas - 2.49
+      Tomatoes: 1.80
+      Yogurt 2.10
+      1. Milk - 3,40 EUR
+      - Bread - 1.20
+    `);
+
+    expect(result.items).toEqual([
+      { name: "Bananas", price: "2.49" },
+      { name: "Tomatoes", price: "1.80" },
+      { name: "Yogurt", price: "2.10" },
+      { name: "Milk", price: "3.40" },
+      { name: "Bread", price: "1.20" }
+    ]);
+  });
+
+  it("accepts simple csv as a fallback", () => {
+    const result = parsePastedItems(`
+      item,price
+      Bananas,2.49
+      Bread,1.20
+    `);
+
+    expect(result.items).toEqual([
+      { name: "Bananas", price: "2.49" },
+      { name: "Bread", price: "1.20" }
+    ]);
+  });
+
+  it("reports ignored malformed lines", () => {
+    const result = parsePastedItems(`
+      Bananas - 2.49
+      total 5.00
+      ????
+    `);
+
+    expect(result.items).toEqual([{ name: "Bananas", price: "2.49" }]);
+    expect(result.ignoredLines).toEqual(["total 5.00", "????"]);
+    expect(result.warnings).toContainEqual({
+      code: "ignored-paste-lines",
+      message: "Ignored 2 pasted lines that did not match the expected format."
+    });
+  });
+
+  it("warns when nothing valid is parsed", () => {
+    const result = parsePastedItems("hello world");
+
+    expect(result.items).toEqual([]);
+    expect(result.warnings).toContainEqual({
+      code: "no-items-detected",
+      message: "No valid items were detected. Use lines like `Bananas - 2.49`, `Bananas 2.49`, or `item,price`."
+    });
+  });
+});

--- a/src/receipt-import/parsePastedItems.ts
+++ b/src/receipt-import/parsePastedItems.ts
@@ -20,7 +20,7 @@ const PASTE_SUMMARY_LABELS = [
 function normalizePrice(rawValue: string) {
   const cleaned = rawValue
     .trim()
-    .replace(/[€$£]|eur|usd|gbp/gi, "")
+    .replace(/[\u20AC\u0024\u00A3]|eur|usd|gbp/gi, "")
     .replace(/\s+/g, "");
 
   if (!cleaned) {
@@ -56,8 +56,10 @@ function parseLineFormat(line: string) {
   }
 
   const withoutPrefix = trimmed.replace(/^(?:[-*]\s*|\d+[.)]\s*)/, "").trim();
+  const separatorMatch = withoutPrefix.match(
+    /^(.*?)(?:\s+-\s+|:\s*)([-\d.,\s\u20AC\u0024\u00A3A-Za-z]+)$/
+  );
 
-  const separatorMatch = withoutPrefix.match(/^(.*?)(?:\s+-\s+|:\s*)([-\d.,\s€$£A-Za-z]+)$/);
   if (!separatorMatch) {
     return null;
   }
@@ -79,7 +81,8 @@ function parseTrailingPriceLine(line: string) {
   }
 
   const withoutPrefix = trimmed.replace(/^(?:[-*]\s*|\d+[.)]\s*)/, "").trim();
-  const trailingPriceMatch = withoutPrefix.match(/^(.*\S)\s+([-\d.,â‚¬$Â£A-Za-z]+)$/);
+  const trailingPriceMatch = withoutPrefix.match(/^(.*\S)\s+([-\d.,\u20AC\u0024\u00A3A-Za-z]+)$/);
+
   if (!trailingPriceMatch) {
     return null;
   }
@@ -149,6 +152,7 @@ export function parsePastedItems(input: string): ParsedPasteImportResult {
   });
 
   const warnings: ReceiptImportWarning[] = [];
+
   if (ignoredLines.length > 0) {
     warnings.push({
       code: "ignored-paste-lines",

--- a/src/receipt-import/parsePastedItems.ts
+++ b/src/receipt-import/parsePastedItems.ts
@@ -1,0 +1,171 @@
+import type { ReceiptImportItem, ReceiptImportWarning } from "./types";
+
+export type ParsedPasteImportResult = {
+  items: ReceiptImportItem[];
+  warnings: ReceiptImportWarning[];
+  ignoredLines: string[];
+};
+
+const PASTE_SUMMARY_LABELS = [
+  "total",
+  "subtotal",
+  "tax",
+  "vat",
+  "paid",
+  "payment",
+  "cash",
+  "card"
+];
+
+function normalizePrice(rawValue: string) {
+  const cleaned = rawValue
+    .trim()
+    .replace(/[€$£]|eur|usd|gbp/gi, "")
+    .replace(/\s+/g, "");
+
+  if (!cleaned) {
+    return null;
+  }
+
+  const commaCount = (cleaned.match(/,/g) ?? []).length;
+  const dotCount = (cleaned.match(/\./g) ?? []).length;
+
+  let normalized = cleaned;
+  if (commaCount > 0 && dotCount > 0) {
+    normalized = cleaned.replace(/\./g, "").replace(",", ".");
+  } else if (commaCount > 0) {
+    normalized = cleaned.replace(",", ".");
+  }
+
+  if (!/^-?\d+(?:\.\d{1,2})?$/.test(normalized)) {
+    return null;
+  }
+
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  return parsed.toFixed(2);
+}
+
+function parseLineFormat(line: string) {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const withoutPrefix = trimmed.replace(/^(?:[-*]\s*|\d+[.)]\s*)/, "").trim();
+
+  const separatorMatch = withoutPrefix.match(/^(.*?)(?:\s+-\s+|:\s*)([-\d.,\s€$£A-Za-z]+)$/);
+  if (!separatorMatch) {
+    return null;
+  }
+
+  const name = separatorMatch[1]?.trim();
+  const price = normalizePrice(separatorMatch[2] ?? "");
+
+  if (!name || !price) {
+    return null;
+  }
+
+  return { name, price };
+}
+
+function parseTrailingPriceLine(line: string) {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const withoutPrefix = trimmed.replace(/^(?:[-*]\s*|\d+[.)]\s*)/, "").trim();
+  const trailingPriceMatch = withoutPrefix.match(/^(.*\S)\s+([-\d.,â‚¬$Â£A-Za-z]+)$/);
+  if (!trailingPriceMatch) {
+    return null;
+  }
+
+  const name = trailingPriceMatch[1]?.trim();
+  const price = normalizePrice(trailingPriceMatch[2] ?? "");
+  const normalizedName = name?.toLowerCase();
+
+  if (
+    !name ||
+    !price ||
+    !normalizedName ||
+    PASTE_SUMMARY_LABELS.some((label) => normalizedName === label || normalizedName.startsWith(`${label} `))
+  ) {
+    return null;
+  }
+
+  return { name, price };
+}
+
+function parseCsvLine(line: string) {
+  const parts = line
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  const [name, priceRaw] = parts;
+  const lowerName = name.toLowerCase();
+  const lowerPrice = priceRaw.toLowerCase();
+
+  if (
+    (lowerName === "item" || lowerName === "name") &&
+    (lowerPrice === "price" || lowerPrice === "amount")
+  ) {
+    return null;
+  }
+
+  const price = normalizePrice(priceRaw);
+  if (!name || !price) {
+    return null;
+  }
+
+  return { name, price };
+}
+
+export function parsePastedItems(input: string): ParsedPasteImportResult {
+  const lines = input
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  const items: ReceiptImportItem[] = [];
+  const ignoredLines: string[] = [];
+
+  lines.forEach((line) => {
+    const parsed = parseLineFormat(line) ?? parseCsvLine(line) ?? parseTrailingPriceLine(line);
+    if (parsed) {
+      items.push(parsed);
+      return;
+    }
+
+    ignoredLines.push(line);
+  });
+
+  const warnings: ReceiptImportWarning[] = [];
+  if (ignoredLines.length > 0) {
+    warnings.push({
+      code: "ignored-paste-lines",
+      message: `Ignored ${ignoredLines.length} pasted line${ignoredLines.length === 1 ? "" : "s"} that did not match the expected format.`
+    });
+  }
+
+  if (items.length === 0) {
+    warnings.push({
+      code: "no-items-detected",
+      message: "No valid items were detected. Use lines like `Bananas - 2.49`, `Bananas 2.49`, or `item,price`."
+    });
+  }
+
+  return {
+    items,
+    warnings,
+    ignoredLines
+  };
+}

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -3,6 +3,15 @@ import { expect, test } from "@playwright/test";
 test("splits a simple grocery receipt", async ({ page }) => {
   await page.addInitScript(() => {
     window.localStorage.clear();
+    window.__openedUrls = [] as string[];
+    window.open = ((url?: string | URL) => {
+      if (typeof url === "string") {
+        window.__openedUrls.push(url);
+      } else if (url) {
+        window.__openedUrls.push(url.toString());
+      }
+      return null;
+    }) as typeof window.open;
     window.__splitBillReceiptImportMock = async () => ({
       source: "image",
       fileName: "receipt.png",
@@ -35,6 +44,7 @@ test("splits a simple grocery receipt", async ({ page }) => {
     mimeType: "image/png",
     buffer: Buffer.from("mock-receipt")
   });
+  await page.getByRole("button", { name: "Apply import" }).click();
   await expect(page.getByText(/Imported 2 items from receipt\.png/)).toBeVisible();
   await expect(page.getByRole("textbox", { name: "Item name" }).nth(1)).toHaveValue("Apples");
   await expect(page.getByRole("textbox", { name: "Item name" }).nth(2)).toHaveValue("Bread");
@@ -53,4 +63,51 @@ test("splits a simple grocery receipt", async ({ page }) => {
   const download = await downloadPromise;
 
   expect(download.suggestedFilename()).toMatch(/^split-bill-\d{4}-\d{2}-\d{2}\.pdf$/);
+});
+
+test("supports ai handoff and pasted import replacement", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.clear();
+    window.__openedUrls = [] as string[];
+    window.open = ((url?: string | URL) => {
+      if (typeof url === "string") {
+        window.__openedUrls.push(url);
+      } else if (url) {
+        window.__openedUrls.push(url.toString());
+      }
+      return null;
+    }) as typeof window.open;
+  });
+
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Start splitting" }).click();
+  await page.getByLabel("Add participant").fill("Ana");
+  await page.getByRole("button", { name: "Add" }).click();
+  await page.getByLabel("Add participant").fill("Bruno");
+  await page.getByRole("button", { name: "Add" }).click();
+  await page.getByRole("button", { name: "Continue" }).last().click();
+
+  await page.getByRole("button", { name: "Ask AI" }).click();
+  await expect(page.getByRole("textbox", { name: "Prompt" })).toHaveValue(
+    /Read the uploaded grocery receipt/
+  );
+  await page.getByRole("button", { name: "ChatGPT" }).click();
+  await expect
+    .poll(async () => page.evaluate(() => (window as typeof window & { __openedUrls: string[] }).__openedUrls))
+    .toContain("https://chatgpt.com/");
+
+  await expect(page.getByLabel("Pasted items")).toBeVisible();
+  await page.getByRole("button", { name: "Cancel" }).click();
+  await page.getByRole("button", { name: "Add item" }).last().click();
+  await page.getByRole("textbox", { name: "Item name" }).fill("Milk");
+  await page.getByRole("textbox", { name: "Price" }).fill("5.00");
+  await page.getByRole("button", { name: "Paste list" }).click();
+  await page.getByLabel("Pasted items").fill("Bananas - 2.49\nBread,1.20");
+  await page.getByRole("button", { name: "Import pasted list" }).click();
+  await page.getByRole("radio", { name: "Replace current items" }).check();
+  await page.getByRole("button", { name: "Apply import" }).click();
+
+  await expect(page.getByRole("textbox", { name: "Item name" }).first()).toHaveValue("Bananas");
+  await expect(page.getByRole("textbox", { name: "Item name" }).nth(1)).toHaveValue("Bread");
 });


### PR DESCRIPTION
## Summary
- add Ask AI and Paste list import paths to Step 2
- add shared append/replace import apply flow for file and pasted imports
- add prompt handoff for ChatGPT, Claude, and Gemini
- add tolerant pasted item parsing, including simple Item 2.49 lines
- add paste reset action and AI-to-paste transition

## Validation
- npm run test:run
- npm run test:e2e
- npm run build