### PR TITLE
fix: restore step 2 item name typing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -204,7 +204,10 @@ function App() {
   const autosaveTimeoutRef = useRef<number | null>(null);
 
   function stripTrailingEmptyItemDraft(values: SplitFormValues) {
-    const nextItems = [...values.items];
+    const nextItems = values.items.filter(
+      (item): item is SplitFormValues["items"][number] =>
+        Boolean(item) && typeof item.name === "string" && typeof item.price === "string"
+    );
     const lastItem = nextItems.at(-1);
 
     if (lastItem && !lastItem.name.trim() && !lastItem.price.trim()) {
@@ -284,9 +287,7 @@ function App() {
       return;
     }
 
-    const hasTrailingDraft = items.some((item) => !item.name.trim() && !item.price.trim());
-
-    if (hasTrailingDraft) {
+    if (items.length > 0) {
       return;
     }
 
@@ -442,35 +443,22 @@ function App() {
       return;
     }
 
-    reset({
-      ...currentValues,
-      items: [
-        ...currentValues.items,
-        {
-          ...createEmptyItem(currentValues.participants),
-          name,
-          price
-        }
-      ]
-    });
+    itemsArray.append(
+      {
+        ...createEmptyItem(currentValues.participants),
+        name,
+        price
+      },
+      { shouldFocus: false }
+    );
   }
 
   function removeItem(index: number) {
-    const currentValues = getValues();
-
-    reset({
-      ...currentValues,
-      items: currentValues.items.filter((_, currentIndex) => currentIndex !== index)
-    });
+    itemsArray.remove(index);
   }
 
   function resetItems() {
-    const currentValues = getValues();
-
-    reset({
-      ...currentValues,
-      items: []
-    });
+    itemsArray.replace([]);
     clearErrors("items");
     setReceiptImportStatus({ state: "idle" });
   }
@@ -506,7 +494,11 @@ function App() {
 
     reset({
       ...currentValues,
-      items: [...preservedItems, ...mappedItems]
+      items: [
+        ...preservedItems,
+        ...mappedItems,
+        createEmptyItem(currentValues.participants)
+      ]
     });
   }
 
@@ -1660,5 +1652,3 @@ function App() {
 }
 
 export default App;
-
-

--- a/src/components/WizardSteps.tsx
+++ b/src/components/WizardSteps.tsx
@@ -494,8 +494,8 @@ export const StepItems = memo(function StepItems({
                     </Stack>
                     <Grid container spacing={1.5} alignItems="flex-start">
                     <Grid size={{ xs: 12, md: "grow" }} sx={{ minWidth: 0 }}>
-                      <Stack direction="row" spacing={1.5} alignItems="flex-start" sx={{ display: { xs: "none", md: "flex" } }}>
-                        <Box sx={{ pt: 1 }}>
+                      <Stack direction="row" spacing={1.5} alignItems="flex-start">
+                        <Box sx={{ pt: 1, display: { xs: "none", md: "block" } }}>
                           <SortableInlineHandle id={item.id} />
                         </Box>
                         <TextField
@@ -526,35 +526,6 @@ export const StepItems = memo(function StepItems({
                           }}
                         />
                       </Stack>
-                      <Box sx={{ display: { xs: "block", md: "none" } }}>
-                        <TextField
-                          label="Item name"
-                          placeholder="Tomatoes"
-                          fullWidth
-                          {...register(`items.${index}.name` as const)}
-                          error={Boolean(itemNameError)}
-                          helperText={itemNameError}
-                          onKeyDown={(event) => {
-                            if (event.key === "Enter") {
-                              event.preventDefault();
-                              handleItemSubmitFromEnter(index);
-                            }
-                          }}
-                          inputProps={{ maxLength: ITEM_NAME_MAX_LENGTH }}
-                          sx={{
-                            "& .MuiInputAdornment-root": {
-                              color: "text.secondary",
-                              fontWeight: 700
-                            },
-                            "& .MuiInputBase-input": {
-                              fontWeight: 700
-                            }
-                          }}
-                          InputProps={{
-                            startAdornment: <InputAdornment position="start">#{index + 1}</InputAdornment>
-                          }}
-                        />
-                      </Box>
                     </Grid>
                     <Grid size={{ xs: 12, md: "auto" }} sx={{ minWidth: { md: 260 } }}>
                       <TextField


### PR DESCRIPTION
## Summary
- fix Step 2 item name inputs so typing works again
- remove the duplicate mobile/desktop registered item-name fields per row
- keep the draft-row handling stable without remounting the active input

## Validation
- npm run lint
- npm run build
