### PR TITLE
Fix percent input backspace clearing

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -260,6 +260,39 @@ describe("App", () => {
   );
 
   it(
+    "allows clearing a percent field with backspace before typing a new value",
+    async () => {
+      const user = userEvent.setup();
+      renderApp();
+
+      await user.click(screen.getByRole("button", { name: "Start splitting" }));
+      await addParticipant(user, "Ana");
+      await addParticipant(user, "Bruno");
+      await user.click(getContinueButton());
+      await addItemLine(user, "Milk", "5.00");
+      await removeTrailingDraftItem(user);
+
+      await user.click(screen.getByRole("button", { name: "Percent" }));
+
+      const percentInput = screen
+        .getAllByLabelText("Percent")
+        .find((element): element is HTMLInputElement => element instanceof HTMLInputElement && isVisible(element));
+
+      expect(percentInput).toBeDefined();
+
+      await user.click(percentInput as HTMLInputElement);
+      await user.keyboard("{Backspace}{Backspace}");
+
+      expect(percentInput).toHaveValue(null);
+
+      await user.type(percentInput as HTMLInputElement, "7");
+
+      expect(percentInput).toHaveValue(7);
+    },
+    15000
+  );
+
+  it(
     "allows direct step navigation only within the unlocked range",
     async () => {
       const user = userEvent.setup();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -709,6 +709,19 @@ function App() {
 
   function updatePercentValue(itemIndex: number, participantId: string, nextValue: string) {
     const currentAllocations = getValues(`items.${itemIndex}.allocations`) as AllocationFormValue[];
+
+    if (nextValue.trim() === "") {
+      setItemAllocations(
+        itemIndex,
+        currentAllocations.map((allocation) =>
+          allocation.participantId === participantId
+            ? { ...allocation, percent: nextValue }
+            : allocation
+        )
+      );
+      return;
+    }
+
     const nextAllocations = rebalancePercentAllocations(currentAllocations, participantId, nextValue);
 
     if (!nextAllocations) {
@@ -1660,5 +1673,4 @@ function App() {
 }
 
 export default App;
-
 


### PR DESCRIPTION
## Summary
- allow percent inputs in the split step to be temporarily cleared while editing
- keep the existing rebalance behavior for valid numeric percent entries
- add a regression test for backspacing from a two-digit percent down to empty and typing a new value

## Testing
- npm run lint
- npm run test:run -- -t "allows clearing a percent field with backspace before typing a new value"
- npm run build

## Notes
- a full `src/App.test.tsx` run still has pre-existing unrelated timeout failures in older receipt handoff tests
- Vitest also reports a pre-existing nested-button warning in the split cards
