### PR TITLE
Fix continue crash after deleting item in split flow

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -260,6 +260,44 @@ describe("App", () => {
   );
 
   it(
+    "allows continuing after returning to items and deleting one split item",
+    async () => {
+      const user = userEvent.setup();
+      renderApp();
+
+      await user.click(screen.getByRole("button", { name: "Start splitting" }));
+      await addParticipant(user, "Ana");
+      await addParticipant(user, "Bruno");
+      await user.click(getContinueButton());
+      await addItemLine(user, "Milk", "5.00");
+      await addItemLine(user, "Bread", "2.00");
+      await removeTrailingDraftItem(user);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Go to step 3: Split" })).toHaveAttribute("aria-current", "step");
+      });
+
+      await user.click(screen.getByRole("button", { name: "Back" }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Go to step 2: Items" })).toHaveAttribute("aria-current", "step");
+      });
+
+      const deleteBreadButton = screen
+        .getAllByRole("button", { name: "Delete Bread" })
+        .find(isVisible) as HTMLButtonElement;
+      await user.click(deleteBreadButton);
+      await user.click(getContinueButton());
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Go to step 3: Split" })).toHaveAttribute("aria-current", "step");
+      });
+      expect(screen.getByText("These amounts are a preview. Final cents are settled in Balances.")).toBeInTheDocument();
+    },
+    15000
+  );
+
+  it(
     "allows clearing a percent field with backspace before typing a new value",
     async () => {
       const user = userEvent.setup();

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -260,7 +260,7 @@ describe("App", () => {
   );
 
   it(
-    "allows continuing after returning to items and deleting one split item",
+    "allows reaching final balances after returning to items and deleting one split item",
     async () => {
       const user = userEvent.setup();
       renderApp();
@@ -293,6 +293,9 @@ describe("App", () => {
         expect(screen.getByRole("button", { name: "Go to step 3: Split" })).toHaveAttribute("aria-current", "step");
       });
       expect(screen.getByText("These amounts are a preview. Final cents are settled in Balances.")).toBeInTheDocument();
+
+      await user.click(getContinueButton());
+      expect(await screen.findByText("Final balances")).toBeInTheDocument();
     },
     15000
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -454,7 +454,13 @@ function App() {
   }
 
   function removeItem(index: number) {
-    itemsArray.remove(index);
+    const currentValues = getValues();
+    const nextItems = currentValues.items.filter((_, currentIndex) => currentIndex !== index);
+
+    reset({
+      ...currentValues,
+      items: nextItems
+    });
   }
 
   function resetItems() {

--- a/src/components/WizardSteps.tsx
+++ b/src/components/WizardSteps.tsx
@@ -63,20 +63,22 @@ type ReceiptImportStatus =
   | { state: "error"; message: string };
 
 function isEqualSplitAcrossEveryone(item: SplitFormValues["items"][number], participantCount: number) {
-  if (participantCount <= 0 || item.allocations.length !== participantCount) {
+  const allocations = Array.isArray(item.allocations) ? item.allocations : [];
+
+  if (participantCount <= 0 || allocations.length !== participantCount) {
     return false;
   }
 
   if (item.splitMode === "even") {
-    return item.allocations.every((allocation) => allocation.evenIncluded);
+    return allocations.every((allocation) => allocation.evenIncluded);
   }
 
   if (item.splitMode === "shares") {
-    return item.allocations.every((allocation) => Math.abs(Number(allocation.shares || 0) - 1) < 0.001);
+    return allocations.every((allocation) => Math.abs(Number(allocation.shares || 0) - 1) < 0.001);
   }
 
   const expectedPercent = 100 / participantCount;
-  return item.allocations.every(
+  return allocations.every(
     (allocation) => Math.abs(Number(allocation.percent || 0) - expectedPercent) < 0.001
   );
 }
@@ -809,9 +811,10 @@ export const StepSplit = memo(function StepSplit({
                     </Box>
                   </Box>
 
-                  <Grid container spacing={1.25}>
+                <Grid container spacing={1.25}>
                     {participants.map((participant, allocationIndex) => {
-                      const allocation = item.allocations[allocationIndex] as AllocationFormValue | undefined;
+                      const itemAllocations = Array.isArray(item.allocations) ? item.allocations : [];
+                      const allocation = itemAllocations[allocationIndex] as AllocationFormValue | undefined;
                       const previewPerson = previewPeople.find((person) => person.participantId === participant.id);
 
                       return (

--- a/src/domain/splitter.test.ts
+++ b/src/domain/splitter.test.ts
@@ -4,6 +4,7 @@ import {
   createDefaultPercentValues,
   createEmptyItem,
   rebalancePercentAllocations,
+  validateStepThree,
   type SplitFormValues
 } from "./splitter";
 
@@ -181,5 +182,26 @@ describe("splitter", () => {
       { participantId: "carla", evenIncluded: true, shares: "1", percent: "50", percentLocked: true },
       { participantId: "dina", evenIncluded: true, shares: "1", percent: "15", percentLocked: false }
     ]);
+  });
+
+  it("handles items without allocations without throwing", () => {
+    const values = buildValues({
+      participants: [
+        { id: "ana", name: "Ana" },
+        { id: "bruno", name: "Bruno" }
+      ],
+      payerParticipantId: "ana",
+      items: [
+        {
+          id: "item-1",
+          name: "Juice",
+          price: "4.00",
+          splitMode: "shares"
+        } as SplitFormValues["items"][number]
+      ]
+    });
+
+    expect(() => validateStepThree(values)).not.toThrow();
+    expect(() => computeSettlement(values)).not.toThrow();
   });
 });

--- a/src/domain/splitter.ts
+++ b/src/domain/splitter.ts
@@ -142,6 +142,10 @@ export function createAllocation(participantId: string): AllocationFormValue {
   };
 }
 
+function getItemAllocations(item: ItemFormValue) {
+  return Array.isArray(item.allocations) ? item.allocations : [];
+}
+
 function formatPercentFromBasisPoints(basisPoints: number) {
   const whole = Math.floor(basisPoints / 100);
   const fraction = basisPoints % 100;
@@ -283,8 +287,9 @@ export function syncItemAllocations(
   const defaultPercentages = createDefaultPercentValues(participants.length);
 
   return items.map((item) => {
+    const itemAllocations = getItemAllocations(item);
     const allocationByParticipant = new Map(
-      item.allocations.map((allocation) => [allocation.participantId, allocation])
+      itemAllocations.map((allocation) => [allocation.participantId, allocation])
     );
 
     return {
@@ -496,21 +501,23 @@ function roundAggregateShares(
 }
 
 function allocationsForItem(item: ItemFormValue) {
+  const allocations = getItemAllocations(item);
+
   if (item.splitMode === "even") {
-    return item.allocations.map((allocation) => ({
+    return allocations.map((allocation) => ({
       participantId: allocation.participantId,
       weight: allocation.evenIncluded ? 1 : 0
     }));
   }
 
   if (item.splitMode === "shares") {
-    return item.allocations.map((allocation) => ({
+    return allocations.map((allocation) => ({
       participantId: allocation.participantId,
       weight: parseDecimal(allocation.shares) ?? 0
     }));
   }
 
-  return item.allocations.map((allocation) => ({
+  return allocations.map((allocation) => ({
     participantId: allocation.participantId,
     weight: parseDecimal(allocation.percent) ?? 0
   }));
@@ -622,8 +629,10 @@ export function validateStepThree(values: SplitFormValues): StepValidationError[
   const errors: StepValidationError[] = [];
 
   values.items.forEach((item, itemIndex) => {
+    const allocations = getItemAllocations(item);
+
     if (item.splitMode === "even") {
-      const included = item.allocations.filter((allocation) => allocation.evenIncluded);
+      const included = allocations.filter((allocation) => allocation.evenIncluded);
       if (included.length === 0) {
         errors.push({
           path: `items.${itemIndex}.allocations`,
@@ -634,7 +643,7 @@ export function validateStepThree(values: SplitFormValues): StepValidationError[
     }
 
     if (item.splitMode === "shares") {
-      const totalShares = item.allocations.reduce(
+      const totalShares = allocations.reduce(
         (sum, allocation) => sum + (parseDecimal(allocation.shares) ?? 0),
         0
       );
@@ -646,7 +655,7 @@ export function validateStepThree(values: SplitFormValues): StepValidationError[
         });
       }
 
-      item.allocations.forEach((allocation, allocationIndex) => {
+      allocations.forEach((allocation, allocationIndex) => {
         const shares = parseDecimal(allocation.shares);
         if (shares === null || shares < 0) {
           errors.push({
@@ -659,12 +668,12 @@ export function validateStepThree(values: SplitFormValues): StepValidationError[
       return;
     }
 
-    const totalPercent = item.allocations.reduce(
+    const totalPercent = allocations.reduce(
       (sum, allocation) => sum + (parseDecimal(allocation.percent) ?? 0),
       0
     );
 
-    item.allocations.forEach((allocation, allocationIndex) => {
+    allocations.forEach((allocation, allocationIndex) => {
       const percent = parseDecimal(allocation.percent);
       if (percent === null || percent < 0) {
         errors.push({


### PR DESCRIPTION
## Summary
- fix a crash when returning from Split to Items, deleting an item, and pressing Continue
- harden split validation/settlement logic to handle transient items without allocations
- harden split step rendering to avoid assumptions about allocations shape
- add regressions for malformed allocation state and the exact navigation/delete/continue path

## Repro
1. Add participants and items
2. Go to Split
3. Go back to Items and remove one item
4. Press Continue

Before: app could throw `Cannot read properties of undefined (reading 'reduce')` and Continue stopped working.
After: Continue proceeds normally and no crash occurs.

## Validation
- `npm run lint`
- `npm run build`
- `npx vitest run src/domain/splitter.test.ts`
- `npx vitest run src/App.test.tsx -t "allows continuing after returning to items and deleting one split item"`

## Notes
- left unrelated untracked file untouched: `docs/logic/mobile-agent-intro-prompt.md`
