### PR TITLE
Add person breakdown section to PDF export

### DIFF
--- a/src/pdf/SettlementPdfDocument.tsx
+++ b/src/pdf/SettlementPdfDocument.tsx
@@ -118,6 +118,12 @@ const styles = StyleSheet.create({
     color: "#6E6E73",
     marginBottom: 8
   },
+  personTotal: {
+    fontSize: 11,
+    fontWeight: "bold",
+    marginBottom: 8,
+    color: "#F05D3D"
+  },
   shareRow: {
     flexDirection: "row",
     justifyContent: "space-between",
@@ -193,6 +199,30 @@ export function SettlementPdfDocument({ data }: Props) {
                 <View key={`${item.id}-${share.participantId}`} style={styles.shareRow}>
                   <Text>{share.name}</Text>
                   <Text>{formatPdfMoney(share.amountCents, data.currency)}</Text>
+                </View>
+              ))}
+            </View>
+          ))}
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Person breakdown</Text>
+          <Text style={styles.sectionNote}>{data.note}</Text>
+          {data.personBreakdown.map((person) => (
+            <View key={person.participantId} style={styles.itemCard} wrap={false}>
+              <View style={styles.itemHeader}>
+                <Text style={styles.itemTitle}>{person.name}</Text>
+                <Text style={styles.itemTitle}>
+                  {formatPdfMoney(person.totalAmountCents, data.currency)}
+                </Text>
+              </View>
+              <Text style={styles.personTotal}>
+                Total consumed: {formatPdfMoney(person.totalAmountCents, data.currency)}
+              </Text>
+              {person.items.map((item) => (
+                <View key={`${person.participantId}-${item.itemId}`} style={styles.shareRow}>
+                  <Text>{item.itemName}</Text>
+                  <Text>{formatPdfMoney(item.amountCents, data.currency)}</Text>
                 </View>
               ))}
             </View>

--- a/src/pdf/SettlementPdfDocument.tsx
+++ b/src/pdf/SettlementPdfDocument.tsx
@@ -118,12 +118,6 @@ const styles = StyleSheet.create({
     color: "#6E6E73",
     marginBottom: 8
   },
-  personTotal: {
-    fontSize: 11,
-    fontWeight: "bold",
-    marginBottom: 8,
-    color: "#F05D3D"
-  },
   shareRow: {
     flexDirection: "row",
     justifyContent: "space-between",
@@ -216,9 +210,6 @@ export function SettlementPdfDocument({ data }: Props) {
                   {formatPdfMoney(person.totalAmountCents, data.currency)}
                 </Text>
               </View>
-              <Text style={styles.personTotal}>
-                Total consumed: {formatPdfMoney(person.totalAmountCents, data.currency)}
-              </Text>
               {person.items.map((item) => (
                 <View key={`${person.participantId}-${item.itemId}`} style={styles.shareRow}>
                   <Text>{item.itemName}</Text>

--- a/src/pdf/buildPdfExportData.test.ts
+++ b/src/pdf/buildPdfExportData.test.ts
@@ -94,6 +94,28 @@ describe("buildPdfExportData", () => {
       { participantId: "ana", name: "Ana", amountCents: 100 },
       { participantId: "bruno", name: "Bruno", amountCents: 400 }
     ]);
+    expect(data.personBreakdown).toEqual([
+      {
+        participantId: "ana",
+        name: "Ana",
+        totalAmountCents: 500,
+        items: [
+          { itemId: "even-item", itemName: "Milk", amountCents: 200 },
+          { itemId: "shares-item", itemName: "Cheese", amountCents: 200 },
+          { itemId: "percent-item", itemName: "Juice", amountCents: 100 }
+        ]
+      },
+      {
+        participantId: "bruno",
+        name: "Bruno",
+        totalAmountCents: 700,
+        items: [
+          { itemId: "even-item", itemName: "Milk", amountCents: 200 },
+          { itemId: "shares-item", itemName: "Cheese", amountCents: 100 },
+          { itemId: "percent-item", itemName: "Juice", amountCents: 400 }
+        ]
+      }
+    ]);
   });
 
   it("builds a deterministic filename", () => {

--- a/src/pdf/buildPdfExportData.ts
+++ b/src/pdf/buildPdfExportData.ts
@@ -31,6 +31,19 @@ export type PdfExportItem = {
   shares: PdfExportItemShare[];
 };
 
+export type PdfExportPersonItemShare = {
+  itemId: string;
+  itemName: string;
+  amountCents: number;
+};
+
+export type PdfExportPersonBreakdown = {
+  participantId: string;
+  name: string;
+  totalAmountCents: number;
+  items: PdfExportPersonItemShare[];
+};
+
 export type PdfExportData = {
   appName: string;
   exportDateLabel: string;
@@ -41,6 +54,7 @@ export type PdfExportData = {
   payer: PdfExportPerson;
   people: PdfExportPerson[];
   items: PdfExportItem[];
+  personBreakdown: PdfExportPersonBreakdown[];
 };
 
 function comparePeopleByDisplayOrder<T extends { name: string; isPayer: boolean }>(left: T, right: T) {
@@ -114,6 +128,34 @@ export function buildPdfExportData(values: SplitFormValues, date = new Date()): 
       }))
   }));
 
+  const personBreakdown = settlement.data.people
+    .sort(comparePeopleByDisplayOrder)
+    .map((person) => {
+      const personItems = items
+        .map((item) => {
+          const personShare = item.shares.find((share) => share.participantId === person.participantId);
+          if (!personShare) {
+            return null;
+          }
+
+          return {
+            itemId: item.id,
+            itemName: item.name,
+            amountCents: personShare.amountCents
+          };
+        })
+        .filter((item): item is PdfExportPersonItemShare => item !== null);
+
+      const totalAmountCents = personItems.reduce((sum, item) => sum + item.amountCents, 0);
+
+      return {
+        participantId: person.participantId,
+        name: person.name,
+        totalAmountCents,
+        items: personItems
+      };
+    });
+
   const people = [...settlement.data.people]
     .sort(comparePeopleByDisplayOrder)
     .map((person) => ({
@@ -142,7 +184,8 @@ export function buildPdfExportData(values: SplitFormValues, date = new Date()): 
       netCents: payer.netCents
     },
     people,
-    items
+    items,
+    personBreakdown
   };
 }
 


### PR DESCRIPTION
## Summary
- add person breakdown data grouped by participant in PDF export payload
- render new Person breakdown section after Item breakdown in the PDF document
- add test coverage for per-person totals and item shares

## Validation
- npm run test:run -- src/pdf/buildPdfExportData.test.ts