### PR TITLE
Add privacy policy route

### DIFF
--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,111 @@
+# Privacy Policy
+
+**Split Bill**
+
+Effective date: 2026-06-03
+
+This Privacy Policy explains how Split Bill ("we", "us", or "our") handles information in the Split Bill mobile app and related services.
+
+If you have questions, contact us at:
+
+Email: `miagology-tech@proton.me`
+
+Developer: Miagology
+
+## Summary
+
+Split Bill is designed to work primarily offline. Most bill-splitting data is stored locally on your device. We do not require you to create an account to use the app.
+
+We do collect some limited information through analytics and crash reporting tools on Android, and the app may make limited internet requests for optional features such as exchange-rate lookups and AI handoff.
+
+## Information We Collect
+
+### Information you enter into the app
+
+You may enter information such as:
+
+- owner names
+- participant names
+- bill names
+- item names and prices
+- split allocations and related bill details
+
+This information is stored locally on your device using on-device storage.
+
+### Device and app information
+
+On Android, we use Firebase Analytics and Firebase Crashlytics. These services may collect or process:
+
+- app activity and usage events
+- crash logs and diagnostic information
+- device or app instance identifiers
+- technical information about your device, operating system, and app version
+
+### Information used for optional online features
+
+The app may send limited information to third-party services when you use certain optional features:
+
+- exchange-rate requests may send currency codes to a public exchange-rate API
+- AI handoff features may open third-party apps or websites so you can transfer a prompt or pasted text into a provider of your choice
+
+## How We Use Information
+
+We use information to:
+
+- provide and maintain the app
+- store and display your split records locally
+- calculate bills and settlements
+- improve app stability and performance
+- diagnose and fix crashes
+- provide optional online features such as exchange-rate lookups
+- support optional AI handoff workflows
+
+## Data Sharing
+
+We do not sell your personal information.
+
+We may share information with service providers and third parties only as needed to operate the app and its optional features, including:
+
+- Google Firebase Analytics
+- Google Firebase Crashlytics
+- exchange-rate service providers used by the app
+- third-party AI providers that you choose to open through the app
+
+These services may receive technical data, usage data, crash information, or the content you choose to send through an optional feature.
+
+## Data Storage and Retention
+
+Most app data is stored locally on your device in a SQLite database and remains under your control.
+
+Analytics and crash data may be retained by our service providers according to their own retention policies. We do not use this data to create user accounts.
+
+If you uninstall the app, locally stored app data on your device is generally removed with the app. You may also be able to clear app data through your device settings.
+
+## Security
+
+We use reasonable technical and organizational safeguards designed to protect information. Data transmitted to third-party services is sent over encrypted connections where supported by the service.
+
+No method of transmission or storage is completely secure, and we cannot guarantee absolute security.
+
+## Your Choices
+
+You may be able to:
+
+- stop using optional online features
+- disable notifications through your device settings
+- uninstall the app to remove locally stored data
+- control analytics or crash reporting where your device or app settings provide that option
+
+## Children’s Privacy
+
+Split Bill is not directed to children, and we do not knowingly collect personal information from children.
+
+## Changes to This Policy
+
+We may update this Privacy Policy from time to time. If we make material changes, we will update the effective date above and, where appropriate, provide additional notice.
+
+## Contact Us
+
+If you have any questions about this Privacy Policy or our data practices, contact us at:
+
+Email: `miagology-tech@proton.me`

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
       content="Split supermarket receipts quickly with one payer, item-level allocation, and instant settlement results."
     />
     <link rel="icon" type="image/png" href="/favicon.png" />
-    <title>Split-Bill</title>
+    <title>Split Bill</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -31,6 +31,10 @@ function renderApp() {
   );
 }
 
+function setPathname(pathname: string) {
+  window.history.pushState({}, "", pathname);
+}
+
 function isVisible(element: Element | null): element is HTMLElement {
   if (!(element instanceof HTMLElement)) {
     return false;
@@ -134,6 +138,7 @@ function getVisibleDeleteItemButton() {
 describe("App", () => {
   beforeEach(() => {
     window.localStorage.clear();
+    setPathname("/");
     exportSettlementPdfMock.mockReset();
     importReceiptMock.mockReset();
     clipboardWriteTextMock.mockReset();
@@ -156,12 +161,27 @@ describe("App", () => {
   });
 
   it(
+    "renders the privacy policy route",
+    async () => {
+      setPathname("/privacy");
+      renderApp();
+
+      expect(screen.getByRole("heading", { name: "Split Bill Privacy Policy" })).toBeInTheDocument();
+      expect(screen.getByText("Effective date: 2026-06-03 · Developer: Miagology · Email: miagology-tech@proton.me")).toBeInTheDocument();
+      expect(screen.getByText("Information We Collect")).toBeInTheDocument();
+      expect(screen.getByText("Children's Privacy")).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Back to Split Bill" })).toHaveAttribute("href", "/");
+    }
+  );
+
+  it(
     "walks through the core flow and shows the final settlement",
     async () => {
       const user = userEvent.setup();
       renderApp();
 
       await user.click(screen.getByRole("button", { name: "Start splitting" }));
+      expect(screen.getByRole("link", { name: "Privacy policy" })).toHaveAttribute("href", "/privacy");
       await addParticipant(user, "Ana");
       await addParticipant(user, "Bruno");
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -167,7 +167,8 @@ describe("App", () => {
       renderApp();
 
       expect(screen.getByRole("heading", { name: "Split Bill Privacy Policy" })).toBeInTheDocument();
-      expect(screen.getByText("Effective date: 2026-06-03 · Developer: Miagology · Email: miagology-tech@proton.me")).toBeInTheDocument();
+      expect(screen.getByText(/Effective date:/)).toBeInTheDocument();
+      expect(screen.getByText(/available via the contact form below/)).toBeInTheDocument();
       expect(screen.getByText("Information We Collect")).toBeInTheDocument();
       expect(screen.getByText("Children's Privacy")).toBeInTheDocument();
       expect(screen.getByRole("link", { name: "Back to Split Bill" })).toHaveAttribute("href", "/");
@@ -180,7 +181,6 @@ describe("App", () => {
       const user = userEvent.setup();
       renderApp();
 
-      expect(screen.getByRole("link", { name: "Privacy policy" })).toHaveAttribute("href", "/privacy");
       await user.click(screen.getByRole("button", { name: "Start splitting" }));
       await addParticipant(user, "Ana");
       await addParticipant(user, "Bruno");
@@ -452,7 +452,9 @@ describe("App", () => {
     15000
   );
 
-  it("imports a receipt in step 2 and appends editable items", async () => {
+  it(
+    "imports a receipt in step 2 and appends editable items",
+    async () => {
     importReceiptMock.mockResolvedValueOnce({
       source: "image",
       fileName: "receipt.png",
@@ -485,7 +487,9 @@ describe("App", () => {
       expect(getVisibleInputByValue("Apples")).toBeInTheDocument();
       expect(getVisibleInputByValue("Bread")).toBeInTheDocument();
     expect(screen.getByText("Ignored 1 total or payment lines.")).toBeInTheDocument();
-  });
+    },
+    10000
+  );
 
   it("opens provider handoff, launches the selected provider, and moves into paste mode", async () => {
     const user = userEvent.setup();
@@ -535,7 +539,9 @@ describe("App", () => {
     }
   });
 
-  it("opens the paste dialog after manually copying the ai prompt", async () => {
+  it(
+    "opens the paste dialog after manually copying the ai prompt",
+    async () => {
     const user = userEvent.setup();
     renderApp();
 
@@ -553,7 +559,9 @@ describe("App", () => {
 
     expect(screen.queryByRole("button", { name: "Copy prompt" })).not.toBeInTheDocument();
     expect(screen.getByLabelText("Pasted items")).toBeInTheDocument();
-  });
+    },
+    10000
+  );
 
   it(
     "does not open the paste dialog when the ai handoff dialog is closed normally",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -180,8 +180,8 @@ describe("App", () => {
       const user = userEvent.setup();
       renderApp();
 
-      await user.click(screen.getByRole("button", { name: "Start splitting" }));
       expect(screen.getByRole("link", { name: "Privacy policy" })).toHaveAttribute("href", "/privacy");
+      await user.click(screen.getByRole("button", { name: "Start splitting" }));
       await addParticipant(user, "Ana");
       await addParticipant(user, "Bruno");
 
@@ -555,7 +555,9 @@ describe("App", () => {
     expect(screen.getByLabelText("Pasted items")).toBeInTheDocument();
   });
 
-  it("does not open the paste dialog when the ai handoff dialog is closed normally", async () => {
+  it(
+    "does not open the paste dialog when the ai handoff dialog is closed normally",
+    async () => {
     const user = userEvent.setup();
     renderApp();
 
@@ -572,7 +574,9 @@ describe("App", () => {
       expect(screen.queryByRole("button", { name: "Copy prompt" })).not.toBeInTheDocument();
       expect(screen.queryByLabelText("Pasted items")).not.toBeInTheDocument();
     });
-  });
+    },
+    10000
+  );
 
   it(
     "clears the pasted input with the reset action",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,7 +53,8 @@ import {
   useMemo,
   useRef,
   useState,
-  type ChangeEvent
+  type ChangeEvent,
+  type FormEvent
 } from "react";
 import { useFieldArray, useForm, useWatch } from "react-hook-form";
 import {
@@ -233,16 +234,33 @@ const PRIVACY_POLICY_SECTIONS: PrivacyPolicySection[] = [
       "We may update this Privacy Policy from time to time. If we make material changes, we will update the effective date above and, where appropriate, provide additional notice."
     ]
   },
-  {
-    title: "Contact Us",
-    paragraphs: [
-      "If you have any questions about this Privacy Policy or our data practices, contact us at:",
-      "Email: miagology-tech@proton.me"
-    ]
-  }
 ] as const;
 
 function PrivacyPolicyPage() {
+  const [contactName, setContactName] = useState("");
+  const [contactEmail, setContactEmail] = useState("");
+  const [contactMessage, setContactMessage] = useState("");
+
+  function handleContactSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const subject = encodeURIComponent(
+      `Split Bill privacy policy question${contactName.trim() ? ` from ${contactName.trim()}` : ""}`
+    );
+    const body = encodeURIComponent(
+      [
+        contactName.trim() ? `Name: ${contactName.trim()}` : null,
+        contactEmail.trim() ? `Reply email: ${contactEmail.trim()}` : null,
+        "",
+        contactMessage.trim()
+      ]
+        .filter((line): line is string => line !== null)
+        .join("\n")
+    );
+
+    window.location.href = `mailto:miagology-tech@proton.me?subject=${subject}&body=${body}`;
+  }
+
   return (
     <Box
       sx={{
@@ -258,7 +276,7 @@ function PrivacyPolicyPage() {
             <Chip label="Privacy policy" color="primary" sx={{ alignSelf: "flex-start", fontWeight: 700 }} />
             <Typography variant="h1">Split Bill Privacy Policy</Typography>
             <Typography color="text.secondary">
-              Effective date: 2026-06-03 · Developer: Miagology · Email: miagology-tech@proton.me
+              Effective date: 2026-06-03 · Developer: Miagology · Email: available via the contact form below
             </Typography>
             <Typography color="text.secondary">
               Split Bill is designed to work primarily offline, with optional online features for exchange-rate lookups and AI handoff.
@@ -301,9 +319,41 @@ function PrivacyPolicyPage() {
             </Card>
           ))}
 
-          <Button component="a" href="/" variant="contained" sx={{ alignSelf: "flex-start" }}>
-            Back to Split Bill
-          </Button>
+          <Card variant="outlined" sx={{ borderRadius: 2 }}>
+            <CardContent>
+              <Stack component="form" spacing={2} onSubmit={handleContactSubmit}>
+                <Typography variant="h2">Contact Us</Typography>
+                <Typography color="text.secondary">
+                  Use this form to open your email app with a prefilled message. We’ll use the details you enter only to reply.
+                </Typography>
+                <TextField label="Name" value={contactName} onChange={(event) => setContactName(event.target.value)} fullWidth />
+                <TextField
+                  label="Email"
+                  type="email"
+                  value={contactEmail}
+                  onChange={(event) => setContactEmail(event.target.value)}
+                  fullWidth
+                />
+                <TextField
+                  label="Message"
+                  value={contactMessage}
+                  onChange={(event) => setContactMessage(event.target.value)}
+                  multiline
+                  minRows={5}
+                  fullWidth
+                  required
+                />
+                <Stack direction={{ xs: "column", sm: "row" }} spacing={1.5}>
+                  <Button type="submit" variant="contained" disabled={!contactMessage.trim()}>
+                    Open email app
+                  </Button>
+                  <Button component="a" href="/" variant="outlined" sx={{ alignSelf: "flex-start" }}>
+                    Back to Split Bill
+                  </Button>
+                </Stack>
+              </Stack>
+            </CardContent>
+          </Card>
         </Stack>
       </Box>
     </Box>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1249,9 +1249,6 @@ function App() {
                     >
                       Start splitting
                     </Button>
-                    <Button component="a" href="/privacy" variant="text" sx={{ alignSelf: "flex-start" }}>
-                      Privacy policy
-                    </Button>
                   </Stack>
                 </Stack>
               </Grid>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -148,6 +148,7 @@ const PRIVACY_POLICY_SECTIONS: PrivacyPolicySection[] = [
     title: "Summary",
     paragraphs: [
       "Split Bill is designed to work primarily offline. Most bill-splitting data is stored locally on your device. We do not require you to create an account to use the app.",
+      "This Privacy Policy applies only to the Split Bill mobile application.",
       "We do collect some limited information through analytics and crash reporting tools on Android, and the app may make limited internet requests for optional features such as exchange-rate lookups and AI handoff."
     ]
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -126,7 +126,195 @@ const STEP_SUMMARIES = [
 const SURFACE_RADIUS = 18;
 const INNER_RADIUS = 14;
 
+type PrivacyPolicySection =
+  | {
+      title: string;
+      paragraphs: string[];
+    }
+  | {
+      title: string;
+      list: string[];
+    }
+  | {
+      title: string;
+      subsections: {
+        title: string;
+        paragraphs: string[];
+      }[];
+    };
+
+const PRIVACY_POLICY_SECTIONS: PrivacyPolicySection[] = [
+  {
+    title: "Summary",
+    paragraphs: [
+      "Split Bill is designed to work primarily offline. Most bill-splitting data is stored locally on your device. We do not require you to create an account to use the app.",
+      "We do collect some limited information through analytics and crash reporting tools on Android, and the app may make limited internet requests for optional features such as exchange-rate lookups and AI handoff."
+    ]
+  },
+  {
+    title: "Information We Collect",
+    subsections: [
+      {
+        title: "Information you enter into the app",
+        paragraphs: [
+          "You may enter information such as owner names, participant names, bill names, item names and prices, split allocations, and related bill details.",
+          "This information is stored locally on your device using on-device storage."
+        ]
+      },
+      {
+        title: "Device and app information",
+        paragraphs: [
+          "On Android, we use Firebase Analytics and Firebase Crashlytics. These services may collect or process app activity and usage events, crash logs and diagnostic information, device or app instance identifiers, and technical information about your device, operating system, and app version."
+        ]
+      },
+      {
+        title: "Information used for optional online features",
+        paragraphs: [
+          "The app may send limited information to third-party services when you use certain optional features.",
+          "Exchange-rate requests may send currency codes to a public exchange-rate API, and AI handoff features may open third-party apps or websites so you can transfer a prompt or pasted text into a provider of your choice."
+        ]
+      }
+    ]
+  },
+  {
+    title: "How We Use Information",
+    list: [
+      "provide and maintain the app",
+      "store and display your split records locally",
+      "calculate bills and settlements",
+      "improve app stability and performance",
+      "diagnose and fix crashes",
+      "provide optional online features such as exchange-rate lookups",
+      "support optional AI handoff workflows"
+    ]
+  },
+  {
+    title: "Data Sharing",
+    paragraphs: [
+      "We do not sell your personal information.",
+      "We may share information with service providers and third parties only as needed to operate the app and its optional features, including Google Firebase Analytics, Google Firebase Crashlytics, exchange-rate service providers used by the app, and third-party AI providers that you choose to open through the app.",
+      "These services may receive technical data, usage data, crash information, or the content you choose to send through an optional feature."
+    ]
+  },
+  {
+    title: "Data Storage and Retention",
+    paragraphs: [
+      "Most app data is stored locally on your device in a SQLite database and remains under your control.",
+      "Analytics and crash data may be retained by our service providers according to their own retention policies. We do not use this data to create user accounts.",
+      "If you uninstall the app, locally stored app data on your device is generally removed with the app. You may also be able to clear app data through your device settings."
+    ]
+  },
+  {
+    title: "Security",
+    paragraphs: [
+      "We use reasonable technical and organizational safeguards designed to protect information. Data transmitted to third-party services is sent over encrypted connections where supported by the service.",
+      "No method of transmission or storage is completely secure, and we cannot guarantee absolute security."
+    ]
+  },
+  {
+    title: "Your Choices",
+    list: [
+      "stop using optional online features",
+      "disable notifications through your device settings",
+      "uninstall the app to remove locally stored data",
+      "control analytics or crash reporting where your device or app settings provide that option"
+    ]
+  },
+  {
+    title: "Children's Privacy",
+    paragraphs: [
+      "Split Bill is not directed to children, and we do not knowingly collect personal information from children."
+    ]
+  },
+  {
+    title: "Changes to This Policy",
+    paragraphs: [
+      "We may update this Privacy Policy from time to time. If we make material changes, we will update the effective date above and, where appropriate, provide additional notice."
+    ]
+  },
+  {
+    title: "Contact Us",
+    paragraphs: [
+      "If you have any questions about this Privacy Policy or our data practices, contact us at:",
+      "Email: miagology-tech@proton.me"
+    ]
+  }
+] as const;
+
+function PrivacyPolicyPage() {
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        bgcolor: "background.default",
+        backgroundImage:
+          "radial-gradient(circle at top left, rgba(239,91,60,0.12), transparent 30%), radial-gradient(circle at right 20%, rgba(15,118,110,0.12), transparent 25%), linear-gradient(180deg, #FFF8F2 0%, #FFFDFC 72%)"
+      }}
+    >
+      <Box sx={{ maxWidth: 900, mx: "auto", px: { xs: 2, md: 4 }, py: { xs: 4, md: 6 } }}>
+        <Stack spacing={3}>
+          <Stack spacing={1.5}>
+            <Chip label="Privacy policy" color="primary" sx={{ alignSelf: "flex-start", fontWeight: 700 }} />
+            <Typography variant="h1">Split Bill Privacy Policy</Typography>
+            <Typography color="text.secondary">
+              Effective date: 2026-06-03 · Developer: Miagology · Email: miagology-tech@proton.me
+            </Typography>
+            <Typography color="text.secondary">
+              Split Bill is designed to work primarily offline, with optional online features for exchange-rate lookups and AI handoff.
+            </Typography>
+          </Stack>
+
+          {PRIVACY_POLICY_SECTIONS.map((section) => (
+            <Card key={section.title} variant="outlined" sx={{ borderRadius: 4 }}>
+              <CardContent>
+                <Stack spacing={1.5}>
+                  <Typography variant="h2">{section.title}</Typography>
+                  {"paragraphs" in section &&
+                    section.paragraphs.map((paragraph) => (
+                      <Typography key={paragraph} color="text.secondary">
+                        {paragraph}
+                      </Typography>
+                    ))}
+                  {"list" in section && (
+                    <Box component="ul" sx={{ m: 0, pl: 3, color: "text.secondary" }}>
+                      {section.list.map((item) => (
+                        <Box component="li" key={item} sx={{ mb: 0.75 }}>
+                          <Typography color="text.secondary">{item}</Typography>
+                        </Box>
+                      ))}
+                    </Box>
+                  )}
+                  {"subsections" in section &&
+                    section.subsections.map((subsection) => (
+                      <Stack key={subsection.title} spacing={1} sx={{ pt: 0.5 }}>
+                        <Typography variant="h3">{subsection.title}</Typography>
+                        {subsection.paragraphs.map((paragraph) => (
+                          <Typography key={paragraph} color="text.secondary">
+                            {paragraph}
+                          </Typography>
+                        ))}
+                      </Stack>
+                    ))}
+                </Stack>
+              </CardContent>
+            </Card>
+          ))}
+
+          <Button component="a" href="/" variant="contained" sx={{ alignSelf: "flex-start" }}>
+            Back to Split Bill
+          </Button>
+        </Stack>
+      </Box>
+    </Box>
+  );
+}
+
 function App() {
+  const pathname = window.location.pathname.replace(/\/$/, "") || "/";
+  if (pathname === "/privacy") {
+    return <PrivacyPolicyPage />;
+  }
+
   const storedDraft = loadStoredDraft();
   const [hasStarted, setHasStarted] = useState(false);
   const [activeStep, setActiveStep] = useState(0);
@@ -1009,6 +1197,9 @@ function App() {
                       }}
                     >
                       Start splitting
+                    </Button>
+                    <Button component="a" href="/privacy" variant="text" sx={{ alignSelf: "flex-start" }}>
+                      Privacy policy
                     </Button>
                   </Stack>
                 </Stack>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -265,7 +265,7 @@ function PrivacyPolicyPage() {
           </Stack>
 
           {PRIVACY_POLICY_SECTIONS.map((section) => (
-            <Card key={section.title} variant="outlined" sx={{ borderRadius: 4 }}>
+            <Card key={section.title} variant="outlined" sx={{ borderRadius: 2 }}>
               <CardContent>
                 <Stack spacing={1.5}>
                   <Typography variant="h2">{section.title}</Typography>


### PR DESCRIPTION
## Summary\n- add a dedicated /privacy page rendered from the privacy policy document\n- keep the split-bill app as the default route\n- update the main page with a privacy-policy link\n\n## Checks\n- npm run lint\n- npm run build\n- npx vitest run src/App.test.tsx -t " renders the privacy policy route\